### PR TITLE
Add sysinfo to PY2

### DIFF
--- a/dmoj/executors/PY2.py
+++ b/dmoj/executors/PY2.py
@@ -6,7 +6,7 @@ class Executor(PythonExecutor):
     command = env['runtime'].get('python')
     test_program = "print __import__('sys').stdin.read()"
     name = 'PY2'
-
+    syscalls = ['sysinfo']
     fs = ['.*\.(?:so|py[co]?$)', '.*/lib(?:32|64)?/python[\d.]+/.*', '.*/lib/locale/', '/proc/meminfo$',
           '/etc/localtime$', '/dev/urandom$']
     if 'python2dir' in env:


### PR DESCRIPTION
During self-testing on Ubuntu 16.04, Python 2 would get a segmentation fault. This is the change to fix this.