### PR TITLE
Update RUST.py

### DIFF
--- a/dmoj/executors/RUST.py
+++ b/dmoj/executors/RUST.py
@@ -5,15 +5,17 @@ from .base_executor import CompiledExecutor
 
 CARGO_TOML = '''\
 [package]
-name = "{name}"
+name = "user_submission"
 version = "1.0.0"
 
 [dependencies]
-dmoj = "0.1.2"
+dmoj = "0.1"
+rand = "0.3"
 '''
 
 HELLO_WORLD_PROGRAM = '''\
 #[macro_use] extern crate dmoj;
+extern crate rand;
 
 fn main() {
     println!("echo: Hello, World!");
@@ -32,10 +34,10 @@ class Executor(CompiledExecutor):
             f.write(source_code)
 
         with open(self._file('Cargo.toml'), 'wb') as f:
-            f.write(CARGO_TOML.format(name=problem_id))
+            f.write(CARGO_TOML)
 
     def get_compile_args(self):
         return [self.get_command(), 'build', '--release']
 
     def get_compiled_file(self):
-        return self._file('target', 'release', self.problem)
+        return self._file('target', 'release', 'user_submission')


### PR DESCRIPTION
- Add rand crate
- Loosen dmoj crate version
- Don't try to be clever with the package name. It was possible for the rust compiler to fail if the problem name had non-identifier characters.