### PR TITLE
Add Short Circuiting for Zero Point Batches

### DIFF
--- a/dmoj/judge.py
+++ b/dmoj/judge.py
@@ -191,11 +191,11 @@ class Judge(object):
             # Yield notifying objects for batch begin/end, and unwrap all cases inside the batches
             if isinstance(case, BatchedTestCase):
                 yield BatchBegin()
-                for c in self.grade_cases(grader, case.batched_cases, short_circuit=True,
+                for batched_case in self.grade_cases(grader, case.batched_cases, short_circuit=True,
                                           is_short_circuiting=is_short_circuiting):
-                    if (c.result_flag & Result.WA) > 0 and not case.points:
+                    if (batched_case.result_flag & Result.WA) > 0 and not case.points:
                         is_short_circuiting = True
-                    yield c
+                    yield batched_case
                 yield BatchEnd()
                 continue
 

--- a/dmoj/judge.py
+++ b/dmoj/judge.py
@@ -191,9 +191,11 @@ class Judge(object):
             # Yield notifying objects for batch begin/end, and unwrap all cases inside the batches
             if isinstance(case, BatchedTestCase):
                 yield BatchBegin()
-                for _ in self.grade_cases(grader, case.batched_cases, short_circuit=True,
+                for c in self.grade_cases(grader, case.batched_cases, short_circuit=True,
                                           is_short_circuiting=is_short_circuiting):
-                    yield _
+                    if (c.result_flag & Result.WA) > 0 and case.config.points == 0:
+                        is_short_circuiting = True
+                    yield c
                 yield BatchEnd()
                 continue
 

--- a/dmoj/judge.py
+++ b/dmoj/judge.py
@@ -193,7 +193,7 @@ class Judge(object):
                 yield BatchBegin()
                 for c in self.grade_cases(grader, case.batched_cases, short_circuit=True,
                                           is_short_circuiting=is_short_circuiting):
-                    if (c.result_flag & Result.WA) > 0 and case.config.points == 0:
+                    if (c.result_flag & Result.WA) > 0 and not case.points:
                         is_short_circuiting = True
                     yield c
                 yield BatchEnd()
@@ -217,7 +217,7 @@ class Judge(object):
             # If the WA bit of result_flag is set and we are set to short-circuit (e.g., in a batch),
             # short circuit the rest of the cases.
             # Do the same if the case is a pretest (i.e. has 0 points)
-            if (result.result_flag & Result.WA) > 0 and (short_circuit or case.points == 0):
+            if (result.result_flag & Result.WA) > 0 and (short_circuit or not case.points):
                 is_short_circuiting = True
 
             yield result

--- a/dmoj/problem.py
+++ b/dmoj/problem.py
@@ -99,6 +99,7 @@ class BatchedTestCase(object):
     def __init__(self, batch_no, config, problem):
         self.config = config
         self.batch_no = batch_no
+        self.points = config.points
         self.batched_cases = problem._resolve_testcases(config['batched'], batch_no=batch_no)
         if any(isinstance(case, BatchedTestCase) for case in self.batched_cases):
             raise InvalidInitException("nested batches")


### PR DESCRIPTION
Make 0 point batch test cases act like pretests
Also add a `points` field to `BatchedTestCase`.