### PR TITLE
Allow batches to not short circuit

### DIFF
--- a/dmoj/judge.py
+++ b/dmoj/judge.py
@@ -194,7 +194,8 @@ class Judge(object):
             # Yield notifying objects for batch begin/end, and unwrap all cases inside the batches
             if isinstance(case, BatchedTestCase):
                 yield BatchBegin()
-                for batched_case in self.grade_cases(grader, case.batched_cases, short_circuit=True,
+                for batched_case in self.grade_cases(grader, case.batched_cases,
+                                          short_circuit=case.config['sc'] is None or case.config['sc'],
                                           is_short_circuiting=is_short_circuiting):
                     if (batched_case.result_flag & Result.WA) > 0 and not case.points:
                         is_short_circuiting = True

--- a/dmoj/judge.py
+++ b/dmoj/judge.py
@@ -195,7 +195,7 @@ class Judge(object):
             if isinstance(case, BatchedTestCase):
                 yield BatchBegin()
                 for batched_case in self.grade_cases(grader, case.batched_cases,
-                                          short_circuit=case.config['sc'] is None or case.config['sc'],
+                                          short_circuit=case.config['short_circuit'],
                                           is_short_circuiting=is_short_circuiting):
                     if (batched_case.result_flag & Result.WA) > 0 and not case.points:
                         is_short_circuiting = True

--- a/dmoj/problem.py
+++ b/dmoj/problem.py
@@ -38,6 +38,7 @@ class Problem(object):
                 'output_prefix_length': 64,
                 'output_limit_length': 25165824,
                 'binary_data': False,
+                'short_circuit': True,
             })
         except (IOError, ParserError, ScannerError) as e:
             raise InvalidInitException(str(e))
@@ -99,9 +100,10 @@ class ProblemDataManager(dict):
 
 class BatchedTestCase(object):
     def __init__(self, batch_no, config, problem):
-        self.config = ConfigNode(config.raw_config, defaults={
-            'short_circuit': True
-        })
+#        self.config = ConfigNode(config.raw_config, defaults={
+#            'short_circuit': True
+#        })
+        self.config = config
         self.batch_no = batch_no
         self.points = config.points
         self.batched_cases = problem._resolve_testcases(config['batched'], batch_no=batch_no)

--- a/dmoj/problem.py
+++ b/dmoj/problem.py
@@ -99,7 +99,9 @@ class ProblemDataManager(dict):
 
 class BatchedTestCase(object):
     def __init__(self, batch_no, config, problem):
-        self.config = config
+        self.config = ConfigNode(config.raw_config, defaults={
+            'short_circuit': True
+        })
         self.batch_no = batch_no
         self.points = config.points
         self.batched_cases = problem._resolve_testcases(config['batched'], batch_no=batch_no)

--- a/dmoj/problem.py
+++ b/dmoj/problem.py
@@ -100,9 +100,6 @@ class ProblemDataManager(dict):
 
 class BatchedTestCase(object):
     def __init__(self, batch_no, config, problem):
-#        self.config = ConfigNode(config.raw_config, defaults={
-#            'short_circuit': True
-#        })
         self.config = config
         self.batch_no = batch_no
         self.points = config.points


### PR DESCRIPTION
Allow for a key, `sc`, within the `init.yml` to dictate on a per-batch basis whether or not said batch should be short circuited. Can be combined with #212 .