### PR TITLE
Fixes for Coffee, PHP, and R

### DIFF
--- a/dmoj/executors/COFFEE.py
+++ b/dmoj/executors/COFFEE.py
@@ -7,7 +7,7 @@ class Executor(ScriptExecutor):
     ext = '.coffee'
     name = 'COFFEE'
     nproc = -1
-    fs = ['/etc/(?:resolv|nsswitch).conf$', '/$']
+    fs = ['/etc/(?:resolv|nsswitch).conf$', '/$', '/dev/pts/.*$']
     command = 'node'
     syscalls = ['newselect', 'select', 'pipe2', 'poll', 'write', 'epoll_create1',
                 'eventfd2', 'epoll_ctl', 'epoll_wait', 'sched_yield', 'restart_syscall',

--- a/dmoj/executors/R.py
+++ b/dmoj/executors/R.py
@@ -16,9 +16,9 @@ class Executor(ScriptDirectoryMixin, ScriptExecutor):
 
     if os.name != 'nt':
         syscalls = ['mkdir', 'setup', 'fork', 'waitpid', 'wait4', 'getpgrp', 'execve',
-                    ('statfs64', ACCESS_DENIED), ('statfs', ACCESS_DENIED)]
+                    ('statfs64', ACCESS_DENIED), ('statfs', ACCESS_DENIED), 'newfstatat', 'unlinkat', 'openat']
 
-    fs = ['/etc/passwd$', '/etc/nsswitch.conf$', '/etc/group$']
+    fs = ['/etc/passwd$', '/etc/nsswitch.conf$', '/etc/group$', '/usr/lib/R/.*$', '/usr/share/locale/locale.alias$', '/sys/devices/system/cpu$', '/proc/filesystems$']
 
     def get_cmdline(self):
         return [self.get_command(), '--vanilla', self._code]

--- a/dmoj/executors/php_executor.py
+++ b/dmoj/executors/php_executor.py
@@ -6,7 +6,7 @@ class PHPExecutor(ScriptExecutor):
     address_grace = 131072
     test_program = '<?php while($f = fgets(STDIN)) echo $f;'
 
-    fs = ['.*/php[\w-]*\.ini$', '.*/conf.d/.*\.ini$', '/etc/nsswitch.conf$']
+    fs = ['.*/php[\w-]*\.ini$', '.*/conf.d/.*\.ini$', '/etc/nsswitch.conf$', '.*/conf.d$']
 
     def get_cmdline(self):
         return ['php', self._code]


### PR DESCRIPTION
On my Debian Stretch box, the three languages need these modifications to pass self-tests. However, I have to admit that I'm not well-versed in security stuff, and it would be great if someone can double-check that this patch does not create security implications :)