### PR TITLE
Normalize `process_output`

### DIFF
--- a/dmoj/checkers/floats.py
+++ b/dmoj/checkers/floats.py
@@ -1,10 +1,14 @@
+from re import split as resplit
+
 from six.moves import zip, filter
+
+from dmoj.utils.unicode import utf8bytes
 
 
 def check(process_output, judge_output, precision, **kwargs):
     # Discount empty lines
-    process_lines = list(filter(None, process_output.split(b'\n')))
-    judge_lines = list(filter(None, judge_output.split(b'\n')))
+    process_lines = list(filter(None, resplit(b'[\r\n]', utf8bytes(process_output))))
+    judge_lines = list(filter(None, resplit(b'[\r\n]', utf8bytes(judge_output))))
 
     if len(process_lines) != len(judge_lines):
         return False

--- a/dmoj/checkers/floatsabs.py
+++ b/dmoj/checkers/floatsabs.py
@@ -1,9 +1,13 @@
+from re import split as resplit
+
 from six.moves import zip, filter
+
+from dmoj.utils.unicode import utf8bytes
 
 
 def check(process_output, judge_output, precision, **kwargs):
-    process_lines = list(filter(None, process_output.split(b'\n')))
-    judge_lines = list(filter(None, judge_output.split(b'\n')))
+    process_lines = list(filter(None, resplit(b'[\r\n]', utf8bytes(process_output)))
+    judge_lines = list(filter(None, resplit(b'[\r\n]', judge_output)))
 
     if len(process_lines) != len(judge_lines):
         return False

--- a/dmoj/checkers/floatsabs.py
+++ b/dmoj/checkers/floatsabs.py
@@ -7,7 +7,7 @@ from dmoj.utils.unicode import utf8bytes
 
 def check(process_output, judge_output, precision, **kwargs):
     process_lines = list(filter(None, resplit(b'[\r\n]', utf8bytes(process_output))))
-    judge_lines = list(filter(None, resplit(b'[\r\n]', judge_output)))
+    judge_lines = list(filter(None, resplit(b'[\r\n]', utf8bytes(judge_output))))
 
     if len(process_lines) != len(judge_lines):
         return False

--- a/dmoj/checkers/floatsabs.py
+++ b/dmoj/checkers/floatsabs.py
@@ -6,7 +6,7 @@ from dmoj.utils.unicode import utf8bytes
 
 
 def check(process_output, judge_output, precision, **kwargs):
-    process_lines = list(filter(None, resplit(b'[\r\n]', utf8bytes(process_output)))
+    process_lines = list(filter(None, resplit(b'[\r\n]', utf8bytes(process_output))))
     judge_lines = list(filter(None, resplit(b'[\r\n]', judge_output)))
 
     if len(process_lines) != len(judge_lines):

--- a/dmoj/checkers/floatsrel.py
+++ b/dmoj/checkers/floatsrel.py
@@ -1,9 +1,12 @@
+from re import split as resplit
+
 from six.moves import zip, filter
 
+from dmoj.utils.unicode import utf8bytes
 
 def check(process_output, judge_output, precision, **kwargs):
-    process_lines = list(filter(None, process_output.split(b'\n')))
-    judge_lines = list(filter(None, judge_output.split(b'\n')))
+    process_lines = list(filter(None, resplit(b'[\r\n]', utf8bytes(process_output))))
+    judge_lines = list(filter(None, resplit(b'[\r\n]', utf8bytes(judge_output))))
 
     if len(process_lines) != len(judge_lines):
         return False

--- a/dmoj/checkers/linecount.py
+++ b/dmoj/checkers/linecount.py
@@ -11,8 +11,8 @@ verdict = u"\u2717\u2713"
 
 def check(process_output, judge_output, point_value, feedback=False,
           match=lambda p, j: p.strip() == j.strip(), **kwargs):
-    process_lines = list(filter(None, resplit(b'[\r\n]', utf8bytes(process_output.strip()))))
-    judge_lines = list(filter(None, resplit(b'[\r\n]', utf8bytes(judge_output.strip()))))
+    process_lines = list(filter(None, resplit(b'[\r\n]', utf8bytes(process_output))))
+    judge_lines = list(filter(None, resplit(b'[\r\n]', utf8bytes(judge_output))))
 
     if len(process_lines) > len(judge_lines):
         return False

--- a/dmoj/checkers/linecount.py
+++ b/dmoj/checkers/linecount.py
@@ -11,7 +11,7 @@ verdict = u"\u2717\u2713"
 
 def check(process_output, judge_output, point_value, feedback=False,
           match=lambda p, j: p.strip() == j.strip(), **kwargs):
-    process_lines = list(filter(None, resplit(b'[\r\n]', utf8bytes(process_output.strip()))
+    process_lines = list(filter(None, resplit(b'[\r\n]', utf8bytes(process_output.strip()))))
     judge_lines = list(filter(None, resplit(b'[\r\n]', utf8bytes(judge_output.strip()))))
 
     if len(process_lines) > len(judge_lines):

--- a/dmoj/checkers/linecount.py
+++ b/dmoj/checkers/linecount.py
@@ -1,15 +1,18 @@
+from re import split as resplit
+
 import six
 from six.moves import filter, zip
 
 from dmoj.result import CheckerResult
+from dmoj.utils.unicode import utf8bytes
 
 verdict = u"\u2717\u2713"
 
 
 def check(process_output, judge_output, point_value, feedback=False,
           match=lambda p, j: p.strip() == j.strip(), **kwargs):
-    process_lines = list(filter(None, process_output.strip().split(b'\n')))
-    judge_lines = list(filter(None, judge_output.strip().split(b'\n')))
+    process_lines = list(filter(None, resplit(b'[\r\n]', utf8bytes(process_output.strip()))
+    judge_lines = list(filter(None, resplit(b'[\r\n]', utf8bytes(judge_output.strip()))))
 
     if len(process_lines) > len(judge_lines):
         return False

--- a/dmoj/checkers/rstripped.py
+++ b/dmoj/checkers/rstripped.py
@@ -1,9 +1,13 @@
+from re import split as resplit
+
 from six.moves import zip, filter
+
+from dmoj.utils.unicode import utf8bytes
 
 
 def check(process_output, judge_output, **kwargs):
-    process_lines = process_output.split(b'\n')
-    judge_lines = judge_output.split(b'\n')
+    process_lines = resplit(b'[\r\n]', utf8bytes(process_output))
+    judge_lines = resplit(b'[\r\n]', utf8bytes(judge_output))
 
     if 'filter_new_line' in kwargs:
         process_lines = list(filter(None, process_lines))

--- a/dmoj/checkers/sorted.py
+++ b/dmoj/checkers/sorted.py
@@ -1,3 +1,5 @@
+from re import split as resplit
+
 import six
 from six.moves import map, zip, filter
 
@@ -5,8 +7,8 @@ from dmoj.utils.unicode import utf8bytes
 
 
 def check(process_output, judge_output, **kwargs):
-    process_lines = list(filter(None, utf8bytes(process_output).split(b'\n')))
-    judge_lines = list(filter(None, utf8bytes(judge_output).split(b'\n')))
+    process_lines = list(filter(None, resplit(b'[\r\n]', utf8bytes(process_output))))
+    judge_lines = list(filter(None, resplit(b'[\r\n]', utf8bytes(judge_output))))
 
     if len(process_lines) != len(judge_lines):
         return False

--- a/dmoj/graders/standard.py
+++ b/dmoj/graders/standard.py
@@ -109,7 +109,7 @@ class StandardGrader(BaseGrader):
                                    case_position=case.position,
                                    batch=case.batch,
                                    submission_language=self.language,
-                                   binary_data=case.has_binary_data())
+                                   binary_data=case.has_binary_data)
         else:
             # Solution is guaranteed to receive 0 points
             check = False

--- a/dmoj/graders/standard.py
+++ b/dmoj/graders/standard.py
@@ -94,16 +94,6 @@ class StandardGrader(BaseGrader):
             }.get(callname, '%s syscall disallowed' % callname)
             result.feedback = message
 
-    def _normalize(self, data, binary_data):
-        # Perhaps the correct answer may be "no output", in which case it'll be None here if
-        # sourced from a generator
-        data = data or b''
-        # Normalize all newline formats (\r\n, \r, \n) to \n, otherwise we have problems with people creating
-        # data on Macs (\r newline) when judged programs assume \n
-        if binary_data:
-            return data
-        return data.replace(b'\r\n', b'\r').replace(b'\r', b'\n')
-
     def check_result(self, case, result):
         # If the submission didn't crash and didn't time out, there's a chance it might be AC
         # We shouldn't run checkers if the submission is already known to be incorrect, because some checkers
@@ -111,14 +101,15 @@ class StandardGrader(BaseGrader):
         # See https://github.com/DMOJ/judge/issues/170
         if not result.result_flag:
             # Checkers might crash if any data is None, so force at least empty string
-            check = case.checker()(self._normalize(result.proc_output, case.binary_data()) or b'',
+            check = case.checker()(result.proc_output,
                                    case.output_data() or b'',
                                    submission_source=self.source,
                                    judge_input=case.input_data() or b'',
                                    point_value=case.points,
                                    case_position=case.position,
                                    batch=case.batch,
-                                   submission_language=self.language)
+                                   submission_language=self.language,
+                                   binary_data=case.binary_data())
         else:
             # Solution is guaranteed to receive 0 points
             check = False

--- a/dmoj/graders/standard.py
+++ b/dmoj/graders/standard.py
@@ -109,7 +109,7 @@ class StandardGrader(BaseGrader):
                                    case_position=case.position,
                                    batch=case.batch,
                                    submission_language=self.language,
-                                   binary_data=case.binary_data())
+                                   binary_data=case.has_binary_data())
         else:
             # Solution is guaranteed to receive 0 points
             check = False

--- a/dmoj/graders/standard.py
+++ b/dmoj/graders/standard.py
@@ -101,7 +101,7 @@ class StandardGrader(BaseGrader):
         # See https://github.com/DMOJ/judge/issues/170
         if not result.result_flag:
             # Checkers might crash if any data is None, so force at least empty string
-            check = case.checker()(result.proc_output,
+            check = case.checker()(result.proc_output or b'',
                                    case.output_data() or b'',
                                    submission_source=self.source,
                                    judge_input=case.input_data() or b'',

--- a/dmoj/problem.py
+++ b/dmoj/problem.py
@@ -123,8 +123,8 @@ class TestCase(object):
         self.problem = problem
         self.points = config.points
         self.output_prefix_length = config.output_prefix_length
-        self._generated = None
         self.has_binary_data = config.binary_data
+        self._generated = None
 
     def io_redirects(self):
         redirects = self.config.io_redirects

--- a/dmoj/problem.py
+++ b/dmoj/problem.py
@@ -158,13 +158,17 @@ class TestCase(object):
 
         return filtered_data
 
+    # this method exists solely because it will be called by the grader to check if it should normalize
+    def binary_data(self):
+        return self.config.binary_data
+
     def _normalize(self, data):
         # Perhaps the correct answer may be "no output", in which case it'll be None here if
         # sourced from a generator
         data = data or b''
         # Normalize all newline formats (\r\n, \r, \n) to \n, otherwise we have problems with people creating
         # data on Macs (\r newline) when judged programs assume \n
-        if self.config.binary_data:
+        if self.binary_data():
             return data
         return data.replace(b'\r\n', b'\r').replace(b'\r', b'\n')
 

--- a/dmoj/problem.py
+++ b/dmoj/problem.py
@@ -124,6 +124,7 @@ class TestCase(object):
         self.points = config.points
         self.output_prefix_length = config.output_prefix_length
         self._generated = None
+        self.has_binary_data = config.binary_data
 
     def io_redirects(self):
         redirects = self.config.io_redirects
@@ -158,16 +159,13 @@ class TestCase(object):
 
         return filtered_data
 
-    def has_binary_data(self):
-        return self.config.binary_data
-
     def _normalize(self, data):
         # Perhaps the correct answer may be "no output", in which case it'll be None here if
         # sourced from a generator
         data = data or b''
         # Normalize all newline formats (\r\n, \r, \n) to \n, otherwise we have problems with people creating
         # data on Macs (\r newline) when judged programs assume \n
-        if self.has_binary_data():
+        if self.has_binary_data:
             return data
         return data.replace(b'\r\n', b'\r').replace(b'\r', b'\n')
 

--- a/dmoj/problem.py
+++ b/dmoj/problem.py
@@ -158,8 +158,7 @@ class TestCase(object):
 
         return filtered_data
 
-    # this method exists solely because it will be called by the grader to check if it should normalize
-    def binary_data(self):
+    def has_binary_data(self):
         return self.config.binary_data
 
     def _normalize(self, data):
@@ -168,7 +167,7 @@ class TestCase(object):
         data = data or b''
         # Normalize all newline formats (\r\n, \r, \n) to \n, otherwise we have problems with people creating
         # data on Macs (\r newline) when judged programs assume \n
-        if self.binary_data():
+        if self.has_binary_data():
             return data
         return data.replace(b'\r\n', b'\r').replace(b'\r', b'\n')
 


### PR DESCRIPTION
Normalize `process_output`, which will prevent checkers like `floats`, etc, from failing on Windows due to the presence of `\r\n`.