### PR TITLE
Attempt to untoast Ruby CI test

### DIFF
--- a/.travis.test.py
+++ b/.travis.test.py
@@ -28,7 +28,7 @@ def main():
     judgeenv.env['extra_fs'] = {
         'PHP': ['/etc/php5/', '/etc/terminfo/', '/etc/protocols$'],
         'SWIFT': [os.path.abspath(os.path.join(os.path.dirname(__file__), 'swift'))],
-        'RUBY2': ['/home/travis/.gem/'],
+        'RUBY2': ['/home/travis/.gem/', '/home'],
     }
 
     print('Available JVMs:')


### PR DESCRIPTION
Adding `/home` to Ruby's `extra_fs` allows the auto-configuration to work.