### PR TITLE
Detect Unicode Classes in Java; #311

### DIFF
--- a/dmoj/executors/java_executor.py
+++ b/dmoj/executors/java_executor.py
@@ -204,7 +204,7 @@ class JavacExecutor(JavaExecutor):
         # This step is necessary because of Unicode classnames
         try:
             source_code = utf8text(source_code)
-        except UnicodeEncodeError:
+        except UnicodeDecodeError:
             raise CompileError('Your UTF-8 is bad, and you should feel bad')
         class_name = find_class(source_code)
         self._code = self._file('%s.java' % class_name.group(1))

--- a/dmoj/executors/java_executor.py
+++ b/dmoj/executors/java_executor.py
@@ -16,7 +16,7 @@ from .base_executor import CompiledExecutor
 recomment = re.compile(br'/\*.*?\*/', re.DOTALL)
 restring = re.compile(br''''(?:\\.|[^'\\])'|"(?:\\.|[^"\\])*"''', re.DOTALL)
 reinline_comment = re.compile(br'//.*?(?=[\r\n])')
-reclass = re.compile(br'\bpublic\s+(?:strictfp\s+)?(?:(?:abstract|final)\s+)?(?:strictfp\s+)?class\s+([_a-zA-Z\$][_0-9a-zA-z\$]*?)\b')
+reclass = re.compile(br'\bpublic\s+(?:strictfp\s+)?(?:(?:abstract|final)\s+)?(?:strictfp\s+)?class\s+([\$\w][\$\w]*?)\b',re.U)
 repackage = re.compile(br'\bpackage\s+([^.;]+(?:\.[^.;]+)*?);')
 redeunicode = re.compile(br'\\u([0-9a-f]{4})', re.I)
 deunicode = lambda x: redeunicode.sub(lambda a: six.unichr(int(a.group(1), 16)), x)

--- a/dmoj/executors/java_executor.py
+++ b/dmoj/executors/java_executor.py
@@ -202,7 +202,10 @@ class JavacExecutor(JavaExecutor):
     def create_files(self, problem_id, source_code, *args, **kwargs):
         super(JavacExecutor, self).create_files(problem_id, source_code, *args, **kwargs)
         # This step is necessary because of Unicode classnames
-        source_code = utf8text(source_code)
+        try:
+            source_code = utf8text(source_code)
+        except UnicodeEncodeError:
+            raise CompileError('Your UTF-8 is bad, and you should feel bad')
         class_name = find_class(source_code)
         self._code = self._file('%s.java' % class_name.group(1))
         try:

--- a/dmoj/executors/java_executor.py
+++ b/dmoj/executors/java_executor.py
@@ -13,11 +13,11 @@ from dmoj.result import Result
 from dmoj.utils.unicode import utf8bytes, utf8text
 from .base_executor import CompiledExecutor
 
-recomment = re.compile(r'/\*.*?\*/', re.DOTALL)
-restring = re.compile(r''''(?:\\.|[^'\\])'|"(?:\\.|[^"\\])*"''', re.DOTALL)
-reinline_comment = re.compile(r'//.*?(?=[\r\n])')
-reclass = re.compile(r'\bpublic\s+(?:strictfp\s+)?(?:(?:abstract|final)\s+)?(?:strictfp\s+)?class\s+([\w\$][\w\$]*?)\b',re.U)
-repackage = re.compile(r'\bpackage\s+([^.;]+(?:\.[^.;]+)*?);')
+recomment = re.compile(r'/\*.*?\*/', re.DOTALL | re.U)
+restring = re.compile(r''''(?:\\.|[^'\\])'|"(?:\\.|[^"\\])*"''', re.DOTALL | re.U)
+reinline_comment = re.compile(r'//.*?(?=[\r\n])', re.U)
+reclass = re.compile(r'\bpublic\s+(?:strictfp\s+)?(?:(?:abstract|final)\s+)?(?:strictfp\s+)?class\s+([\w\$][\w\$]*?)\b', re.U)
+repackage = re.compile(r'\bpackage\s+([^.;]+(?:\.[^.;]+)*?);', re.U)
 
 
 JAVA_SANDBOX = os.path.abspath(os.path.join(os.path.dirname(__file__), 'java_sandbox.jar'))

--- a/dmoj/executors/java_executor.py
+++ b/dmoj/executors/java_executor.py
@@ -16,10 +16,8 @@ from .base_executor import CompiledExecutor
 recomment = re.compile(br'/\*.*?\*/', re.DOTALL)
 restring = re.compile(br''''(?:\\.|[^'\\])'|"(?:\\.|[^"\\])*"''', re.DOTALL)
 reinline_comment = re.compile(br'//.*?(?=[\r\n])')
-reclass = re.compile(br'\bpublic\s+(?:strictfp\s+)?(?:(?:abstract|final)\s+)?(?:strictfp\s+)?class\s+([\$\w][\$\w]*?)\b',re.U)
+reclass = re.compile(br'\bpublic\s+(?:strictfp\s+)?(?:(?:abstract|final)\s+)?(?:strictfp\s+)?class\s+(\$?[\$\w]*?)\b',re.U)
 repackage = re.compile(br'\bpackage\s+([^.;]+(?:\.[^.;]+)*?);')
-redeunicode = re.compile(br'\\u([0-9a-f]{4})', re.I)
-deunicode = lambda x: redeunicode.sub(lambda a: six.unichr(int(a.group(1), 16)), x)
 
 
 JAVA_SANDBOX = os.path.abspath(os.path.join(os.path.dirname(__file__), 'java_sandbox.jar'))
@@ -203,7 +201,6 @@ class JavaExecutor(CompiledExecutor):
 class JavacExecutor(JavaExecutor):
     def create_files(self, problem_id, source_code, *args, **kwargs):
         super(JavacExecutor, self).create_files(problem_id, source_code, *args, **kwargs)
-        source_code = deunicode(source_code)
         class_name = find_class(source_code)
         self._code = self._file('%s.java' % utf8text(class_name.group(1)))
         try:

--- a/dmoj/executors/mixins.py
+++ b/dmoj/executors/mixins.py
@@ -108,7 +108,7 @@ try:
                 return self.address_grace
 
             def get_env(self):
-                env = {'LANG': 'C'}
+                env = {'LANG': 'C.UTF-8'}
                 if self.unbuffered:
                     env['CPTBOX_STDOUT_BUFFER_SIZE'] = 0
                 return env

--- a/dmoj/tests/test_malformed_unicode.py
+++ b/dmoj/tests/test_malformed_unicode.py
@@ -1,0 +1,22 @@
+import os
+import unittest
+
+from dmoj.error import CompileError
+from dmoj.executors.JAVA8 import Executor as JAVA8Executor
+
+try:
+    from unittest import mock
+except ImportError:
+    import mock
+
+
+class ProblemTest(unittest.TestCase):
+    def test_malformed_unicode(self):
+        source = b'''\
+public class malformed {
+    public static void main(String[] args){
+        S = "\xc1\xbf"; // This is malformed unicode
+    }
+}'''
+        with self.assertRaisesRegexp(CompileError, 'Your UTF-8 is bad, and you should feel bad'):
+            JAVA8Executor('malformed', source)

--- a/dmoj/tests/test_malformed_unicode.py
+++ b/dmoj/tests/test_malformed_unicode.py
@@ -4,11 +4,6 @@ import unittest
 from dmoj.error import CompileError
 from dmoj.executors.JAVA8 import Executor as JAVA8Executor
 
-try:
-    from unittest import mock
-except ImportError:
-    import mock
-
 
 class ProblemTest(unittest.TestCase):
     def test_malformed_unicode(self):


### PR DESCRIPTION
Modified the regexes in `dmoj.executor.java_executor` to account for Unicode submissions, and added a unit test for malformed UTF-8.