### PR TITLE
Gracefully handle no `file` executable

### DIFF
--- a/dmoj/cptbox/sandbox.py
+++ b/dmoj/cptbox/sandbox.py
@@ -40,7 +40,8 @@ def _find_exe(path):
 def file_info(path, split=re.compile(r'[\s,]').split):
     try:
         return split(utf8text(subprocess.check_output(['file', '-b', '-L', path])))
-    except subprocess.CalledProcessError:
+    except (OSError, subprocess.CalledProcessError):
+        log.exception('call to file(1) failed -- does the utility exist?')
         return []
 
 


### PR DESCRIPTION
Some systems (like Termux by default) do not ship with `file(1)`, in which case the judge crashes with a poor error message in unrelated code. Addresses #309.