### PR TITLE
add execution time to checker

### DIFF
--- a/dmoj/graders/standard.py
+++ b/dmoj/graders/standard.py
@@ -109,7 +109,8 @@ class StandardGrader(BaseGrader):
                                    case_position=case.position,
                                    batch=case.batch,
                                    submission_language=self.language,
-                                   binary_data=case.has_binary_data)
+                                   binary_data=case.has_binary_data,
+                                   execution_time=result.execution_time)
         else:
             # Solution is guaranteed to receive 0 points
             check = False


### PR DESCRIPTION
DMOJ does not currently support POI-style grading. This commit exposes execution time to enable POI-style grading as checkers are able to assign custom point values.