### PR TITLE
make presentation error message more user-friendly

### DIFF
--- a/dmoj/checkers/identical.py
+++ b/dmoj/checkers/identical.py
@@ -8,5 +8,5 @@ def check(process_output, judge_output, pe_allowed=True, **kwargs):
     feedback = None
     if pe_allowed and standard(utf8bytes(judge_output), utf8bytes(process_output)):
         # in the event the standard checker would have passed the problem, raise a presentation error
-        feedback = "Presentation Error"
+        feedback = "Presentation Error, check your whitespace"
     return CheckerResult(False, 0, feedback=feedback)


### PR DESCRIPTION
The only people who understand what Presentation Error is are the people who are the least likely to run into it.

Presentation Error is no longer a standard verdict in the modern competitive programming meta. In the interest of being more user-friendly, the recipient is given a explicit call to action.