### PR TITLE
Implement seccomp filtering optimization

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -21,6 +21,7 @@ addons:
     - coffeescript
     - binutils-multiarch
     - libc6-dev-i386
+    - libseccomp-dev
     - nasm
     - open-cobol
     - ocaml

--- a/.travis.yml
+++ b/.travis.yml
@@ -6,6 +6,9 @@ python:
   - 3.4
   - 3.5
   - 3.6
+env:
+- DMOJ_USE_SECCOMP="yes"
+- DMOJ_USE_SECCOMP="no"
 addons:
   apt:
     sources:

--- a/README.md
+++ b/README.md
@@ -80,7 +80,7 @@ The judge can also grade in the languages listed below. These languages are less
 * Tcl
 * Turing
 * V8 JavaScript
-* Brain****
+* Brain\*\*\*\*
 
 ## Installation
 Installing the DMOJ judge creates two executables in your Python's script directory: `dmoj` and `dmoj-cli`.
@@ -109,6 +109,13 @@ $ cd judge
 $ git submodule update --init --recursive
 $ pip install -e .
 ```
+
+Several environment variables can be specified to control the compilation of the sandbox:
+
+* `DMOJ_USE_SECCOMP`; set it to `no` if you're building on a pre-Linux 3.5 kernel to disable `seccomp` filtering in favour of pure `ptrace` (slower).
+   This flag has no effect when building outside of Linux.
+* `DMOJ_TARGET_ARCH`; use it to override the default architecture specified for compiling the sandbox (via `-march`).
+   Usually this is `native`, but will not be specified on ARM unless `DMOJ_TARGET_ARCH` is set (a generic, slow build will be compiled instead).
 
 ## Usage
 ### Running a Judge Server

--- a/dmoj/cptbox/handlers.py
+++ b/dmoj/cptbox/handlers.py
@@ -11,7 +11,7 @@ def errno_handler(code):
         def on_return():
             debugger.result = -code
 
-        debugger.syscall = debugger.getpid_syscall
+        debugger.syscall = -1
         debugger.on_return(on_return)
         return True
     return handler

--- a/dmoj/cptbox/helper.cpp
+++ b/dmoj/cptbox/helper.cpp
@@ -134,7 +134,6 @@ int cptbox_child_run(const struct child_config *config) {
 
     kill(getpid(), SIGSTOP);
 
-
 #if PTBOX_SECCOMP
     if (config->trace_syscalls) {
         scmp_filter_ctx ctx = seccomp_init(SCMP_ACT_TRACE(0));

--- a/dmoj/cptbox/helper.cpp
+++ b/dmoj/cptbox/helper.cpp
@@ -26,6 +26,34 @@
 #   define FD_DIR "/proc/self/fd"
 #endif
 
+inline unsigned int get_seccomp_arch(int type) {
+    switch (type) {
+#ifdef SCMP_ARCH_X86
+        case DEBUGGER_X86:
+        case DEBUGGER_X86_ON_X64:
+            return SCMP_ARCH_X86;
+#endif
+#ifdef SCMP_ARCH_X86_64
+        case DEBUGGER_X64:
+            return SCMP_ARCH_X86_64;
+#endif
+#ifdef SCMP_ARCH_X32
+        case DEBUGGER_X32:
+            return SCMP_ARCH_X32;
+#endif
+#ifdef SCMP_ARCH_ARM
+        case DEBUGGER_ARM:
+            return SCMP_ARCH_ARM;
+#endif
+#ifdef SCMP_ARCH_AARCH64
+        case DEBUGGER_ARM64:
+            return SCMP_ARCH_AARCH64;
+#endif
+    }
+
+    return 0;
+}
+
 pt_debugger *get_ptdebugger(int type) {
     switch (type) {
 #ifdef HAS_DEBUGGER_X86
@@ -103,7 +131,33 @@ int cptbox_child_run(const struct child_config *config) {
 
     if (ptrace_traceme())
         return 204;
+
     kill(getpid(), SIGSTOP);
+
+
+#if PTBOX_SECCOMP
+    if (config->trace_syscalls) {
+        scmp_filter_ctx ctx = seccomp_init(SCMP_ACT_TRACE(0));
+        if (!ctx) return 203;
+
+        unsigned int child_arch = get_seccomp_arch(config->debugger_type);
+
+        if (seccomp_arch_exist(ctx, child_arch) == -EEXIST &&
+            seccomp_arch_add(ctx, child_arch) != 0) {
+            return 203;
+        }
+
+        for (int syscall = 0; syscall < MAX_SYSCALL; syscall++) {
+            if (config->syscall_whitelist[syscall]) {
+                seccomp_rule_add(ctx, SCMP_ACT_ALLOW, syscall, 0);
+            }
+        }
+
+        if (seccomp_load(ctx)) return 203;
+        seccomp_release(ctx);
+    }
+#endif
+
     execve(config->file, config->argv, config->envp);
     return 205;
 }

--- a/dmoj/cptbox/helper.h
+++ b/dmoj/cptbox/helper.h
@@ -26,6 +26,9 @@ struct child_config {
     int stderr_;
     int max_fd;
     int *fds;
+    int debugger_type;
+    int trace_syscalls;
+    int *syscall_whitelist;
 };
 
 void cptbox_closefrom(int lowfd);

--- a/dmoj/cptbox/ptbox.h
+++ b/dmoj/cptbox/ptbox.h
@@ -13,17 +13,17 @@
 
 #include <map>
 
-// TODO: only if seccomp is available
-#define PTBOX_SECCOMP 1
-
-#if PTBOX_SECCOMP
-#include <seccomp.h>
-#endif
-
 #if defined(__FreeBSD__) || defined(__FreeBSD_kernel__)
 #   define PTBOX_FREEBSD 1
 #else
 #   define PTBOX_FREEBSD 0
+#endif
+
+// TODO: only if seccomp is available
+#define PTBOX_SECCOMP !PTBOX_FREEBSD
+
+#if PTBOX_SECCOMP
+#include <seccomp.h>
 #endif
 
 #if defined(__amd64__)

--- a/dmoj/cptbox/ptbox.h
+++ b/dmoj/cptbox/ptbox.h
@@ -19,8 +19,11 @@
 #   define PTBOX_FREEBSD 0
 #endif
 
-// TODO: only if seccomp is available
+#ifndef PTBOX_NO_SECCOMP
 #define PTBOX_SECCOMP !PTBOX_FREEBSD
+#else
+#define PTBOX_SECCOMP 0
+#endif
 
 #if PTBOX_SECCOMP
 #include <seccomp.h>

--- a/dmoj/cptbox/ptbox.h
+++ b/dmoj/cptbox/ptbox.h
@@ -13,6 +13,13 @@
 
 #include <map>
 
+// TODO: only if seccomp is available
+#define PTBOX_SECCOMP 1
+
+#if PTBOX_SECCOMP
+#include <seccomp.h>
+#endif
+
 #if defined(__FreeBSD__) || defined(__FreeBSD_kernel__)
 #   define PTBOX_FREEBSD 1
 #else
@@ -167,7 +174,10 @@ public:
     void setpid(pid_t pid);
 #else
     void settid(pid_t tid);
-    bool is_enter() { return syscall_[tid] != 0; }
+    bool is_enter() {
+      // All seccomp events are enter events.
+      return PTBOX_SECCOMP ? true : syscall_[tid] != 0;
+    }
 #endif
 
     virtual void pre_syscall();

--- a/dmoj/cptbox/ptdebug.cpp
+++ b/dmoj/cptbox/ptdebug.cpp
@@ -56,8 +56,10 @@ void pt_debugger::setpid(pid_t pid) {
 #else
 void pt_debugger::settid(pid_t tid) {
     this->tid = tid;
+#if !PTBOX_SECCOMP // All seccomp syscall events are enter events
     if (!syscall_.count(tid)) syscall_[tid] = 0;
     syscall_[tid] ^= 1;
+#endif
 }
 #endif
 

--- a/dmoj/cptbox/ptproc.cpp
+++ b/dmoj/cptbox/ptproc.cpp
@@ -104,7 +104,7 @@ int pt_process::protection_fault(int syscall) {
 }
 
 int pt_process::monitor() {
-    bool in_syscall = false, first = true, spawned = false;
+    bool in_syscall = false, first = true, spawned = false, execve_allowed = true;
     struct timespec start, end, delta;
     int status, exit_reason = PTBOX_EXIT_NORMAL;
     // Set pgid to -this->pid such that -pgid becomes pid, resulting
@@ -187,139 +187,163 @@ int pt_process::monitor() {
             pgid = pid;
         }
 
-        if (WIFSTOPPED(status)) {
-            //printf("%d: WSTOPSIG(status): %d\n", pid, WSTOPSIG(status));
+        if (!WIFSTOPPED(status)) {
+            goto resume_process;
+        }
+
+        //printf("%d: WSTOPSIG(status): %d\n", pid, WSTOPSIG(status));
 #if PTBOX_FREEBSD
-            if (WSTOPSIG(status) == SIGTRAP && lwpi.pl_flags & (PL_FLAG_SCE | PL_FLAG_SCX)) {
-                debugger->setpid(pid);
-                debugger->update_syscall(&lwpi);
+        if (WSTOPSIG(status) == SIGTRAP && lwpi.pl_flags & (PL_FLAG_SCE | PL_FLAG_SCX)) {
+            debugger->setpid(pid);
+            debugger->update_syscall(&lwpi);
 #else
-    #if PTBOX_SECCOMP
-            if (WSTOPSIG(status) == SIGTRAP && (status >> 16) == PTRACE_EVENT_SECCOMP) {
-    #else
-            if (WSTOPSIG(status) == (0x80 | SIGTRAP)) {
-    #endif
-                debugger->settid(pid);
-                debugger->pre_syscall();
+#if PTBOX_SECCOMP
+        if (WSTOPSIG(status) == SIGTRAP && (status >> 16) == PTRACE_EVENT_SECCOMP) {
+#else
+        if (WSTOPSIG(status) == (0x80 | SIGTRAP)) {
+#endif
+            debugger->settid(pid);
+            debugger->pre_syscall();
 #endif
 #if defined(__FreeBSD_version) && __FreeBSD_version >= 1002501
-                int syscall = lwpi.pl_syscall_code;
+            int syscall = lwpi.pl_syscall_code;
 #else
-                int syscall = debugger->syscall();
+            int syscall = debugger->syscall();
 #endif
 #if PTBOX_FREEBSD
-                in_syscall = lwpi.pl_flags & PL_FLAG_SCE;
+            in_syscall = lwpi.pl_flags & PL_FLAG_SCE;
 #else
-                in_syscall = debugger->is_enter();
+            in_syscall = debugger->is_enter();
 #endif
 
-                //printf("%d: %s syscall %d\n", pid, in_syscall ? "Enter" : "Exit", syscall);
-                if (!spawned) {
-                    // Does execve not return if the process hits an rlimit and gets SIGKILLed?
-                    //
-                    // It doesn't. See the strace below.
-                    //      $ ulimit -Sv50000
-                    //      $ strace ./a.out
-                    //      execve("./a.out", ["./a.out"], [/* 17 vars */] <unfinished ...>
-                    //      +++ killed by SIGKILL +++
-                    //      Killed
-                    //
-                    // From this we can see that execve doesn't return (<unfinished ...>) if the process fails to
-                    // initialize, so we don't need to wait until the next non-execve syscall to set
-                    // _initialized to true - if it exited execve, it's good to go.
-                    // TODO: with seccomp, !in_syscall will never be true -- is this patch OK?
-                    if ((!in_syscall || PTBOX_SECCOMP) && syscall == debugger->execve_syscall()) {
-                        spawned = this->_initialized = true;
+            //printf("%d: %s syscall %d\n", pid, in_syscall ? "Enter" : "Exit", syscall);
+            if (!spawned) {
+                // Detecting whether a process spawned successfully is difficult.
+                //
+                // Without `seccomp`: different kernel versions do different things when
+                // an rlimit is hit during the `execve`. It's possible for the process to
+                // receive a SIGKILL midway through the call; it's also possible for the
+                // call to return with a nonzero value (e.g. -ENOMEM).
+                //
+                // So, we only mark the process as spawned if we receive a post-`execve`
+                // trap (meaning the process was not SIGKILLed halfway through), and the
+                // return value of `execve` is 0.
+                //
+                // With `seccomp`: we have no post-syscall trap, so we mark the process
+                // as spawned when we hit the first non-`execve` syscall. This can be
+                // problematic if we don't trap on exit syscalls, since a simple assembly
+                // program could theoretically run without causing any syscall traps.
+                //
+                // We take some care when building the syscall whitelist to not add exit
+                // syscalls to the whitelist, so that their invocation will cause a trap
+                // (after which they'll go down the PTBOX_HANDLER_ALLOW branch below).
+
+                // Allow exactly one invocation of `execve`, no questions asked.
+                if (syscall == debugger->execve_syscall()) {
+                    if (execve_allowed) {
+                        execve_allowed = false;
+                        goto resume_process;
                     }
-                } else if (in_syscall) {
-                    if (syscall >= 0 && syscall < MAX_SYSCALL) {
-                        switch (handler[syscall]) {
-                            case PTBOX_HANDLER_ALLOW:
-                                if (PTBOX_SECCOMP) {
-                                    //printf("Something is wrong, trapped on allowed syscall\n");
-                                }
-                                break;
-                            case PTBOX_HANDLER_STDOUTERR: {
-                                int arg0 = debugger->arg0();
-                                if (arg0 != 1 && arg0 != 2)
-                                    exit_reason = protection_fault(syscall);
-                                break;
-                            }
-                            case PTBOX_HANDLER_CALLBACK:
-                                if (callback(context, syscall))
-                                    break;
-                                //printf("Killed by callback: %d\n", syscall);
-                                exit_reason = protection_fault(syscall);
-                                continue;
-                            default:
-                                // Default is to kill, safety first.
-                                //printf("Killed by DISALLOW or None: %d\n", syscall);
-                                exit_reason = protection_fault(syscall);
-                                continue;
-                        }
-                    // We pass any system call that we can't record in our fixed-size array to python.
-                    // Python will decide your fate.
-                    } else if (!callback(context, syscall)) {
-                        //printf("Killed by callback: %d\n", syscall);
-                        exit_reason = protection_fault(syscall);
-                        continue;
-                    }
+                    // Fall through to in_syscall branch below, which will kill the process
+                    // if `execve` was invoked more than once without being whitelisted.
                 }
 
-                // Syscall has "ended". What we do here varies a bit between if we're using seccomp
-                // or not, since with seccomp we will have no return event.
-                if ((PTBOX_SECCOMP || !in_syscall) && debugger->on_return_callback) {
-                    debugger->on_return_callback(debugger->on_return_context, syscall);
-                    debugger->on_return_callback = NULL;
-                    debugger->on_return_context = NULL;
-                }
-
-                debugger->post_syscall();
-            } else {
-#if PTBOX_FREEBSD
-                // No events aside from signal event on FreeBSD
-                // (TODO: maybe check for PL_SIGNAL instead of both PL_SIGNAL and PL_NONE?)
-                signal = WSTOPSIG(status);
-
-                // Swallow SIGSTOP. This is because no one should send it, nor should it
-                // be self-send, hence perfect for implementing shocker.
-                if (signal == SIGSTOP)
-                    signal = 0;
+#if PTBOX_SECCOMP
+                if (syscall != debugger->execve_syscall() /* always true */) {
 #else
-                switch (WSTOPSIG(status)) {
-                    case SIGTRAP:
-                        switch (status >> 16) {
-                            case PTRACE_EVENT_EXIT:
-                                if (exit_reason != PTBOX_EXIT_NORMAL) {
-                                    dispatch(PTBOX_EVENT_EXITING, PTBOX_EXIT_NORMAL);
-                                }
-                                break;
-                            case PTRACE_EVENT_CLONE: {
-                                unsigned long tid;
-                                ptrace(PTRACE_GETEVENTMSG, pid, NULL, &tid);
-                                //printf("Created thread: %d\n", tid);
-                                break;
-                            }
-                            case PTRACE_EVENT_FORK:
-                            case PTRACE_EVENT_VFORK: {
-                                unsigned long npid;
-                                ptrace(PTRACE_GETEVENTMSG, pid, NULL, &npid);
-                                children.insert(npid);
-                                //printf("Created process: %d\n", npid);
-                                break;
-                            }
-                        }
-                        break;
-                    default:
-                        signal = WSTOPSIG(status);
-                }
+                if (!in_syscall && syscall == debugger->execve_syscall() && debugger->result() == 0) {
 #endif
-
-                // Only main process signals are meaningful.
-                if (!first && pid == pgid) // *** Don't set _signal to SIGSTOP if this is the /first/ SIGSTOP
-                    dispatch(PTBOX_EVENT_SIGNAL, WSTOPSIG(status));
+                  spawned = this->_initialized = true;
+                  goto resume_process;
+                }
             }
+
+            if (in_syscall) {
+                if (syscall >= 0 && syscall < MAX_SYSCALL) {
+                    switch (handler[syscall]) {
+                        case PTBOX_HANDLER_ALLOW:
+                            break;
+                        case PTBOX_HANDLER_STDOUTERR: {
+                            int arg0 = debugger->arg0();
+                            if (arg0 != 1 && arg0 != 2)
+                                exit_reason = protection_fault(syscall);
+                            break;
+                        }
+                        case PTBOX_HANDLER_CALLBACK:
+                            if (callback(context, syscall))
+                                break;
+                            //printf("Killed by callback: %d\n", syscall);
+                            exit_reason = protection_fault(syscall);
+                            continue;
+                        default:
+                            // Default is to kill, safety first.
+                            //printf("Killed by DISALLOW or None: %d\n", syscall);
+                            exit_reason = protection_fault(syscall);
+                            continue;
+                    }
+                // We pass any system call that we can't record in our fixed-size array to python.
+                // Python will decide your fate.
+                } else if (!callback(context, syscall)) {
+                    //printf("Killed by callback: %d\n", syscall);
+                    exit_reason = protection_fault(syscall);
+                    continue;
+                }
+            }
+
+            // Syscall has "ended". What we do here varies a bit between if we're using seccomp
+            // or not, since with seccomp we will have no return event.
+            if ((PTBOX_SECCOMP || !in_syscall) && debugger->on_return_callback) {
+                debugger->on_return_callback(debugger->on_return_context, syscall);
+                debugger->on_return_callback = NULL;
+                debugger->on_return_context = NULL;
+            }
+
+            debugger->post_syscall();
+        } else {
+#if PTBOX_FREEBSD
+            // No events aside from signal event on FreeBSD
+            // (TODO: maybe check for PL_SIGNAL instead of both PL_SIGNAL and PL_NONE?)
+            signal = WSTOPSIG(status);
+
+            // Swallow SIGSTOP. This is because no one should send it, nor should it
+            // be self-send, hence perfect for implementing shocker.
+            if (signal == SIGSTOP)
+                signal = 0;
+#else
+            switch (WSTOPSIG(status)) {
+                case SIGTRAP:
+                    switch (status >> 16) {
+                        case PTRACE_EVENT_EXIT:
+                            if (exit_reason != PTBOX_EXIT_NORMAL) {
+                                dispatch(PTBOX_EVENT_EXITING, PTBOX_EXIT_NORMAL);
+                            }
+                            break;
+                        case PTRACE_EVENT_CLONE: {
+                            unsigned long tid;
+                            ptrace(PTRACE_GETEVENTMSG, pid, NULL, &tid);
+                            //printf("Created thread: %d\n", tid);
+                            break;
+                        }
+                        case PTRACE_EVENT_FORK:
+                        case PTRACE_EVENT_VFORK: {
+                            unsigned long npid;
+                            ptrace(PTRACE_GETEVENTMSG, pid, NULL, &npid);
+                            children.insert(npid);
+                            //printf("Created process: %d\n", npid);
+                            break;
+                        }
+                    }
+                    break;
+                default:
+                    signal = WSTOPSIG(status);
+            }
+#endif
+
+            // Only main process signals are meaningful.
+            if (!first && pid == pgid) // *** Don't set _signal to SIGSTOP if this is the /first/ SIGSTOP
+                dispatch(PTBOX_EVENT_SIGNAL, WSTOPSIG(status));
         }
+resume_process:
         // Pass NULL as signal in case of our first SIGSTOP because the runtime tends to resend it, making all our
         // work for naught. Like abort(), it catches the signal, prints something (^Z?) and then resends it.
         // Doing this prevents a second SIGSTOP from being dispatched to our event handler above. ***

--- a/dmoj/executors/mono_executor.py
+++ b/dmoj/executors/mono_executor.py
@@ -87,7 +87,7 @@ class MonoExecutor(CompiledExecutor):
             def kill_return():
                 debugger.result = -errno.EPERM
             if debugger.arg0 != debugger.pid:
-                debugger.syscall = debugger.getpid_syscall
+                debugger.syscall = -1
                 debugger.on_return(kill_return)
             return True
 

--- a/dmoj/judge.py
+++ b/dmoj/judge.py
@@ -384,6 +384,16 @@ def sanity_check():
             startup_warnings.append('running the judge as root can be potentially unsafe, '
                                     'consider using an unprivileged user instead')
 
+        # Our sandbox filter is long but simple, so we can see large improvements
+        # in overhead by enabling the BPF JIT for seccomp.
+        bpf_jit_path = '/proc/sys/net/core/bpf_jit_enable'
+        if os.path.exists(bpf_jit_path):
+            with open(bpf_jit_path, 'r') as f:
+                if f.read().strip() != '1':
+                    startup_warnings.append('running without BPF JIT enabled, consider running'
+                                            '`echo 1 > /proc/sys/net/core/bpf_jit_enable` '
+                                            'to reduce sandbox overhead')
+
     # _checker implements standard checker functions in C
     # we fall back to a Python implementation if it's not compiled, but it's slower
     try:

--- a/setup.py
+++ b/setup.py
@@ -112,7 +112,7 @@ if os.name == 'nt' or 'sdist' in sys.argv:
                              define_macros=[('UNICODE', None)])]
 
 if os.name != 'nt' or 'sdist' in sys.argv:
-    libs = ['rt']
+    libs = ['rt', 'seccomp']
     if sys.platform.startswith('freebsd'):
         libs += ['procstat']
 

--- a/setup.py
+++ b/setup.py
@@ -20,6 +20,15 @@ from setuptools.command.build_ext import build_ext
 has_pyx = os.path.exists(os.path.join(os.path.dirname(__file__), 'dmoj', 'cptbox', '_cptbox.pyx'))
 
 try:
+    with open('/proc/version') as f:
+        is_wsl = 'microsoft' in f.read().lower()
+except IOError:
+    is_wsl = False
+
+# Allow manually disabling seccomp on old kernels. WSL doesn't have seccomp.
+has_seccomp = not is_wsl and os.environ.get('DMOJ_USE_SECCOMP') != 'no'
+
+try:
     from Cython.Build import cythonize
 except ImportError:
     if has_pyx:
@@ -70,8 +79,10 @@ class build_ext_dmoj(build_ext, object):
             arch = os.uname()[4]
             is_arm = arch.startswith('arm') or arch.startswith('aarch')
             target_arch = os.environ.get('DMOJ_TARGET_ARCH')
+
+            extra_compile_args = []
             if is_arm or os.environ.get('DMOJ_REDIST'):
-                extra_compile_args = ['-O3']
+                extra_compile_args.append('-O3')
                 if target_arch:
                     extra_compile_args.append('-march=%s' % target_arch)
                 elif is_arm:
@@ -80,7 +91,7 @@ class build_ext_dmoj(build_ext, object):
                     print('Compiling slower generic build.')
                     print('*' * 79)
             else:
-                extra_compile_args = ['-march=%s' % (target_arch or 'native'), '-O3']
+                extra_compile_args += ['-march=%s' % (target_arch or 'native'), '-O3']
             self.distribution.ext_modules[0].extra_compile_args = extra_compile_args
 
         super(build_ext_dmoj, self).build_extensions()
@@ -112,17 +123,23 @@ if os.name == 'nt' or 'sdist' in sys.argv:
                              define_macros=[('UNICODE', None)])]
 
 if os.name != 'nt' or 'sdist' in sys.argv:
-    libs = ['rt', 'seccomp']
+    libs = ['rt']
+
+    if has_seccomp:
+        libs += ['seccomp']
     if sys.platform.startswith('freebsd'):
         libs += ['procstat']
 
     macros = []
-    try:
-        with open('/proc/version') as f:
-            if 'microsoft' in f.read().lower():
-                macros.append(('WSL', None))
-    except IOError:
-        pass
+    if is_wsl:
+        macros.append(('WSL', None))
+
+    if not has_seccomp:
+        print('*' * 79)
+        print('Building without seccomp, expect lower sandbox performance.')
+        print('*' * 79)
+        macros.append(('PTBOX_NO_SECCOMP', None))
+
     extensions += [Extension('dmoj.cptbox._cptbox', sources=cptbox_sources,
                              language='c++', libraries=libs, define_macros=macros)]
 


### PR DESCRIPTION
This change has been tested to work on x64 for a couple of critical
executors. There might exist some loose ends on ARM.

`seccomp` is used to remove the need to return from `ptrace` for all
syscalls that occur, allowing us to selectively filter more dangerous
syscalls (like `open`), while incurring a smaller penalty for frequent,
but harmless, syscalls (like `write`).

There are a number of semantic differences between pure `ptrace` and
`ptrace` + `seccomp`. Notably, where `ptrace` has pre- and post-syscall
events, `ptrace` + `seccomp` only fires a pre-syscall event.
Nonetheless, functionality like switching syscall registers around works
fine in the pre-syscall event.

A smaller distinction as a result of this is that to cancel a syscall, we
need to pass in -1 as the modified syscall, whereas with pure `ptrace` we
would swap the syscall with `getpid` in the post-syscall event. This
distinction is hidden from the Python side (where you can simply pass -1
at all times).

Code that relied both on changing the syscall to perform a different
action *and* changing its return value is now broken when running under
`seccomp`, but I can't think of a reason why anyone would want to do that
-- we certainly dont.