### PR TITLE
Allow generators to specify custom compiler TL; #295

### DIFF
--- a/dmoj/config.py
+++ b/dmoj/config.py
@@ -116,6 +116,9 @@ class ConfigNode(object):
             cfg = self.parent[item] if self.parent else None
         return cfg
 
+    def __len__(self):
+        return len(self.raw_config)
+
     def __setitem__(self, item, value):
         self.raw_config[item] = value
 

--- a/dmoj/generator.py
+++ b/dmoj/generator.py
@@ -39,7 +39,8 @@ class GeneratorManager(object):
         clazz = clazz.Executor
 
         if issubclass(clazz, CompiledExecutor):
-            clazz = type('Executor', (clazz,), {'compiler_time_limit': compiler_time_limit or clazz.compiler_time_limit})
+            compiler_time_limit = compiler_time_limit or clazz.compiler_time_limit
+            clazz = type('Executor', (clazz,), {'compiler_time_limit': compiler_time_limit})
 
         if hasattr(clazz, 'flags'):
             flags += ['-DWINDOWS_JUDGE', '-DWIN32'] if os.name == 'nt' else ['-DLINUX_JUDGE']

--- a/dmoj/generator.py
+++ b/dmoj/generator.py
@@ -6,8 +6,9 @@ from dmoj.utils import ansi
 
 
 class GeneratorManager(object):
-    def get_generator(self, filenames, flags, lang=None):
+    def get_generator(self, filenames, flags, lang=None, compiler_time_limit=None):
         from dmoj.executors import executors
+        from dmoj.executors.base_executor import CompiledExecutor
 
         filenames = list(map(os.path.abspath, filenames))
         sources = {}
@@ -36,6 +37,9 @@ class GeneratorManager(object):
             raise IOError('could not find a C++ executor for generator')
 
         clazz = clazz.Executor
+
+        if issubclass(clazz, CompiledExecutor):
+            clazz = type('Executor', (clazz,), {'compiler_time_limit': compiler_time_limit or clazz.compiler_time_limit})
 
         if hasattr(clazz, 'flags'):
             flags += ['-DWINDOWS_JUDGE', '-DWIN32'] if os.name == 'nt' else ['-DLINUX_JUDGE']

--- a/dmoj/problem.py
+++ b/dmoj/problem.py
@@ -156,6 +156,7 @@ class TestCase(object):
         # resource limits on how to run the generator
         time_limit = env.generator_time_limit
         memory_limit = env.generator_memory_limit
+        compiler_time_limit = env.compiler_time_limit
         use_sandbox = env.generator_sandboxing
         lang = None  # Default to C/C++
 
@@ -174,6 +175,7 @@ class TestCase(object):
 
             time_limit = gen.time_limit or time_limit
             memory_limit = gen.memory_limit or memory_limit
+            compiler_time_limit = gen.compiler_time_limit or compiler_time_limit
             lang = gen.language
 
             # Optionally allow disabling the sandbox
@@ -185,7 +187,7 @@ class TestCase(object):
 
         filenames = [os.path.join(base, name) for name in filenames]
 
-        executor = self.problem.generator_manager.get_generator(filenames, flags, lang=lang)
+        executor = self.problem.generator_manager.get_generator(filenames, flags, lang=lang, compiler_time_limit=compiler_time_limit)
 
         # convert all args to str before launching; allows for smoother int passing
         args = map(str, args)

--- a/dmoj/problem.py
+++ b/dmoj/problem.py
@@ -166,7 +166,11 @@ class TestCase(object):
         elif isinstance(gen.unwrap(), list):
             filenames = list(gen.unwrap())
         else:
-            filenames = gen.source
+            if isinstance(gen.source, six.string_types):
+                filenames = gen.source
+            elif isinstance(gen.source.unwrap(), list):
+                filenames = list(gen.source.unwrap())
+
             if gen.flags:
                 flags += gen.flags
             if not args and gen.args:

--- a/dmoj/problem.py
+++ b/dmoj/problem.py
@@ -191,7 +191,8 @@ class TestCase(object):
 
         filenames = [os.path.join(base, name) for name in filenames]
 
-        executor = self.problem.generator_manager.get_generator(filenames, flags, lang=lang, compiler_time_limit=compiler_time_limit)
+        executor = self.problem.generator_manager.get_generator(filenames, flags, lang=lang,
+                                                                compiler_time_limit=compiler_time_limit)
 
         # convert all args to str before launching; allows for smoother int passing
         args = map(str, args)


### PR DESCRIPTION
By specifying `compiler_time_limit: 60` on the `generator_multifile` test, Appveyor will actually pass all tests.