### PR TITLE
Fixed 4 issues of type: PYTHON_E241 throughout 1 file in repo.

### DIFF
--- a/.travis.test.py
+++ b/.travis.test.py
@@ -17,10 +17,10 @@ PYENV_DIR = '/opt/python/'
 JVM_DIR = '/usr/lib/jvm/'
 
 OVERRIDES = {
-    'PY2':    make_override('py2_home',    PYENV_DIR, r'2\.'),
-    'PY3':    make_override('py3_home',    PYENV_DIR, r'3\.'),
-    'RUBY2':  make_override('ruby2_home',  RVM_DIR,   r'ruby-2\.'),
-    'PYPY':  {'pypy_home':  os.path.abspath('pypy2')},
+    'PY2': make_override('py2_home', PYENV_DIR, r'2\.'),
+    'PY3': make_override('py3_home', PYENV_DIR, r'3\.'),
+    'RUBY2': make_override('ruby2_home', RVM_DIR, r'ruby-2\.'),
+    'PYPY': {'pypy_home': os.path.abspath('pypy2')},
     'PYPY3': {'pypy3_home': os.path.abspath('pypy3')},
 }
 


### PR DESCRIPTION
PYTHON_E241: 'Fix extraneous whitespace around keywords.'.  This is a pep8 error code.          See <a href='https://pep8.readthedocs.io/en/latest/intro.html#error-codes'>        here for a complete list of error codes</a>.

It was fixed with <a href='https://github.com/hhatto/autopep8'>autopep8</a>.  The fix is completely safe.