### PR TITLE
Fixed 6 issues of type: PYTHON_E402 throughout 1 file in repo.

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -1,4 +1,10 @@
 # encoding: utf-8
+import traceback
+import subprocess
+from distutils.errors import DistutilsPlatformError
+from distutils.msvccompiler import MSVCCompiler
+from setuptools import setup, Extension, find_packages
+from setuptools.command.build_ext import build_ext
 from __future__ import print_function
 
 import io
@@ -9,13 +15,7 @@ if sys.version_info[0] >= 3 and os.name == 'nt':
     print('DMOJ is unsupported on Windows Python 3, please use Python 2 instead.', file=sys.stderr)
     sys.exit(0)
 
-import traceback
-import subprocess
-from distutils.errors import DistutilsPlatformError
-from distutils.msvccompiler import MSVCCompiler
 
-from setuptools import setup, Extension, find_packages
-from setuptools.command.build_ext import build_ext
 
 has_pyx = os.path.exists(os.path.join(os.path.dirname(__file__), 'dmoj', 'cptbox', '_cptbox.pyx'))
 


### PR DESCRIPTION
PYTHON_E402: 'module level import not at top of file'.  This is a pep8 error code.          See <a href='https://pep8.readthedocs.io/en/latest/intro.html#error-codes'>        here for a complete list of error codes</a>.

It was fixed with <a href='https://github.com/hhatto/autopep8'>autopep8</a>.  The fix is completely safe.