### PR TITLE
Fixed 5 issues of type: PYTHON_W391 throughout 5 files in repo.

### DIFF
--- a/dmoj/executors/DART.py
+++ b/dmoj/executors/DART.py
@@ -16,4 +16,3 @@ void main() {
     syscalls = ['epoll_create', 'epoll_ctl', 'epoll_wait', 'timerfd_settime', 'pipe2']
 
     fs = ['.*/vm-service$']
-

--- a/dmoj/executors/FORTH.py
+++ b/dmoj/executors/FORTH.py
@@ -15,4 +15,3 @@ HELLO
 
     def get_cmdline(self):
         return [self.get_command(), self._code, '-e', 'bye']
-

--- a/dmoj/executors/MONOVB.py
+++ b/dmoj/executors/MONOVB.py
@@ -38,4 +38,3 @@ End Module
         res = super(Executor, cls).get_find_first_mapping()
         res['mono-vbnc'] = ['mono-vbnc', 'vbnc']
         return res
-

--- a/dmoj/executors/TCL.py
+++ b/dmoj/executors/TCL.py
@@ -27,4 +27,3 @@ puts $input
         process.stdin.close()
         retcode = process.poll()
         return ('tclsh', tuple(map(int, process.stdout.read().split(b'.'))) if not retcode else ()),
-

--- a/dmoj/executors/TEXT.py
+++ b/dmoj/executors/TEXT.py
@@ -7,4 +7,3 @@ class Executor(ScriptExecutor):
     command = 'cat'
     test_program = 'echo: Hello, World!\n'
     syscalls = ['fadvise64_64', 'fadvise64', 'posix_fadvise', 'arm_fadvise64_64']
-


### PR DESCRIPTION
PYTHON_W391: 'blank line at end of file'.  This is a pep8 error code.          See <a href='https://pep8.readthedocs.io/en/latest/intro.html#error-codes'>        here for a complete list of error codes</a>.

It was fixed with <a href='https://github.com/hhatto/autopep8'>autopep8</a>.  The fix is completely safe.