### PR TITLE
Ensure empty newline does not crash CLI

### DIFF
--- a/dmoj/cli.py
+++ b/dmoj/cli.py
@@ -119,7 +119,10 @@ def cli_main():
         register(command(judge))
 
     def run_command(line):
-        if line and line[0] in commands:
+        if not line:
+            return 127
+
+        if line[0] in commands:
             cmd = commands[line[0]]
             try:
                 return cmd.execute(line[1:])

--- a/dmoj/cli.py
+++ b/dmoj/cli.py
@@ -119,7 +119,7 @@ def cli_main():
         register(command(judge))
 
     def run_command(line):
-        if line[0] in commands:
+        if line and line[0] in commands:
             cmd = commands[line[0]]
             try:
                 return cmd.execute(line[1:])


### PR DESCRIPTION
Currently if you give the CLI an empty newline you get:

```
dmoj>
Traceback (most recent call last):
  File "/usr/local/bin/dmoj-cli", line 11, in <module>
    load_entry_point('dmoj', 'console_scripts', 'dmoj-cli')()
  File "/code/judge/dmoj/cli.py", line 85, in main
    sys.exit(cli_main())
  File "/code/judge/dmoj/cli.py", line 145, in cli_main
    run_command(shlex.split(command))
  File "/code/judge/dmoj/cli.py", line 122, in run_command
    if line[0] in commands:
IndexError: list index out of range
```