### PR TITLE
COFFEE: enable `epoll_pwait` syscall

### DIFF
--- a/dmoj/executors/COFFEE.py
+++ b/dmoj/executors/COFFEE.py
@@ -8,8 +8,8 @@ class Executor(ScriptExecutor):
     name = 'COFFEE'
     nproc = -1
     command = 'node'
-    syscalls = ['newselect', 'select', 'pipe2', 'poll', 'write', 'epoll_create1',
-                'eventfd2', 'epoll_ctl', 'epoll_wait', 'sched_yield', 'setrlimit']
+    syscalls = ['newselect', 'select', 'pipe2', 'poll', 'write', 'epoll_create1', 'eventfd2', 'epoll_ctl', 'epoll_wait',
+                'epoll_pwait', 'sched_yield', 'setrlimit']
     test_program = '''\
 process.stdin.on 'readable', () ->
   chunk = process.stdin.read()


### PR DESCRIPTION
The COFFEE self-test fails if you do not enable this syscall.