### PR TITLE
Allow single-digit runtime version formatting

### DIFF
--- a/dmoj/executors/PYPY.py
+++ b/dmoj/executors/PYPY.py
@@ -1,4 +1,3 @@
-from dmoj.executors.base_executor import reversion
 from dmoj.executors.python_executor import PythonExecutor
 
 
@@ -10,7 +9,8 @@ class Executor(PythonExecutor):
     @classmethod
     def parse_version(cls, command, output):
         try:
-            cls._pypy_versions = [tuple(map(int, version.split('.'))) for version in reversion.findall(output)]
+            cls._pypy_versions = [tuple(map(int, version.split('.')))
+                                  for version in cls.version_regex.findall(output)]
             return cls._pypy_versions[1]
         except:
             return None

--- a/dmoj/executors/base_executor.py
+++ b/dmoj/executors/base_executor.py
@@ -24,7 +24,6 @@ from dmoj.utils.error import print_protection_fault
 from dmoj.utils.unicode import utf8bytes, utf8text
 from dmoj.utils.uniprocess import Popen as UniPopen
 
-reversion = re.compile('.*?(\d+(?:\.\d+)+)', re.DOTALL)
 version_cache = {}
 
 
@@ -39,6 +38,7 @@ class BaseExecutor(PlatformExecutorMixin):
     test_name = 'self_test'
     test_time = env.selftest_time_limit
     test_memory = env.selftest_memory_limit
+    version_regex = re.compile('.*?(\d+(?:\.\d+)+)', re.DOTALL)
 
     def __init__(self, problem_id, source_code, dest_dir=None, hints=None,
                  unbuffered=False, **kwargs):
@@ -186,7 +186,7 @@ class BaseExecutor(PlatformExecutorMixin):
 
     @classmethod
     def parse_version(cls, command, output):
-        match = reversion.match(output)
+        match = cls.version_regex.match(output)
         if match:
             return map(int, match.group(1).split('.'))
         return None

--- a/dmoj/executors/gcc_executor.py
+++ b/dmoj/executors/gcc_executor.py
@@ -26,6 +26,7 @@ class GCCExecutor(CompiledExecutor):
     name = 'GCC'
     arch = 'gcc_target_arch'
     has_color = False
+    version_regex = re.compile('.*?(\d+(?:\.\d+)*)', re.DOTALL)
 
     def __init__(self, problem_id, main_source, **kwargs):
         super(GCCExecutor, self).__init__(problem_id, main_source, **kwargs)


### PR DESCRIPTION
`g++` appears to no longer provide minor/bugfix information as of version 8:

```
$ g++ -dumpversion
8
```