### PR TITLE
Allow config keys to have a value of `0`

### DIFF
--- a/dmoj/config.py
+++ b/dmoj/config.py
@@ -81,7 +81,7 @@ class ConfigNode(object):
                 if isinstance(value, list) or isinstance(value, dict) else value
 
     def __getattr__(self, item):
-        return self[item] or self[item.replace('_', '-')]
+        return self[item.replace('_', '-')] if self[item] is None else self[item]
 
     def __getitem__(self, item):
         try:


### PR DESCRIPTION
`0 or None` evaluates to `None`, and with most signature-graded and many custom graded problems setting `output_prefix_length` to `0`, this caused the database to get hammered if a use submitted a program that produced large amounts of output on said problems.