### PR TITLE
Add `$GOCACHE` to compile env

### DIFF
--- a/dmoj/executors/GO.py
+++ b/dmoj/executors/GO.py
@@ -31,9 +31,13 @@ func main() {
 }'''
 
     def get_compile_env(self):
-        # Disable cgo, as it may be used for nefarious things (like linking
-        # against arbitrary libraries).
-        return {'CGO_ENABLED': '0'}
+        return {
+            # Disable cgo, as it may be used for nefarious things, like linking
+            # against arbitrary libraries.
+            'CGO_ENABLED': '0',
+            # We need GOCACHE to compile on Debian 10.0+.
+            'GOCACHE': self._dir,
+        }
 
     def get_compile_args(self):
         return [self.get_command(), 'build', self._code]


### PR DESCRIPTION
This allows GO 1.11.6 to work with the judge.