### PR TITLE
Correctly display clang version

### DIFF
--- a/dmoj/executors/CLANG.py
+++ b/dmoj/executors/CLANG.py
@@ -1,8 +1,8 @@
 from dmoj.executors.C import Executor as CExecutor
+from dmoj.executors.clang_executor import ClangExecutor
 
 
-class Executor(CExecutor):
+class Executor(ClangExecutor, CExecutor):
     command = 'clang'
     command_paths = ['clang-%s' % i for i in ['3.9', '3.8', '3.7', '3.6', '3.5']] + ['clang']
     name = 'CLANG'
-    arch = 'clang_target_arch'

--- a/dmoj/executors/CLANGX.py
+++ b/dmoj/executors/CLANGX.py
@@ -1,8 +1,8 @@
 from dmoj.executors.CPP11 import Executor as CPP11Executor
+from dmoj.executors.clang_executor import ClangExecutor
 
 
-class Executor(CPP11Executor):
+class Executor(ClangExecutor,CPP11Executor):
     command = 'clang++'
     command_paths = ['clang++-%s' % i for i in ['3.9', '3.8', '3.7', '3.6', '3.5']] + ['clang++']
     name = 'CLANG++'
-    arch = 'clang_target_arch'

--- a/dmoj/executors/clang_executor.py
+++ b/dmoj/executors/clang_executor.py
@@ -1,0 +1,9 @@
+from .gcc_executor import GCCExecutor
+
+
+class ClangExecutor(GCCExecutor):
+    arch = 'clang_target_arch'
+
+    @classmethod
+    def get_version_flags(cls, command):
+        return ['--version']


### PR DESCRIPTION
`clang -dumpversion` always returns 4.2.1 for compatibility reasons.