### PR TITLE
Shorten error message when entry point is not found; #366

### DIFF
--- a/dmoj/executors/java_executor.py
+++ b/dmoj/executors/java_executor.py
@@ -114,7 +114,7 @@ class JavaExecutor(CompiledExecutor):
             return ''
 
         if b'Error: Main method not found in class' in stderr:
-            exception = "public static void main(String[] args) entry point not found"
+            exception = "public static void main(String[] args) not found"
         else:
             try:
                 with open(os.path.join(self._dir, 'state'), 'r') as state:


### PR DESCRIPTION
New message is 49 characters long, so it will not be truncated.