### PR TITLE
Bump up ruby command path to support Ruby 2.6

### DIFF
--- a/dmoj/executors/RUBY2.py
+++ b/dmoj/executors/RUBY2.py
@@ -4,7 +4,7 @@ from .ruby_executor import RubyExecutor
 class Executor(RubyExecutor):
     name = 'RUBY2'
     nproc = -1
-    command_paths = (['ruby2.%d' % i for i in reversed(range(0, 5))] +
-                     ['ruby2%d' % i for i in reversed(range(0, 5))])
+    command_paths = (['ruby2.%d' % i for i in reversed(range(0, 7))] +
+                     ['ruby2%d' % i for i in reversed(range(0, 7))])
     syscalls = ['poll', 'thr_set_name']
     fs = ['/proc/self/loginuid$']


### PR DESCRIPTION
The latest stable release of Ruby is 2.6.4, while the current executor only supports up to Ruby 2.4.