### PR TITLE
add mypy_cache to gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -21,6 +21,7 @@ develop-eggs
 lib
 lib64
 __pycache__
+.mypy_cache
 
 # Installer logs
 pip-log.txt


### PR DESCRIPTION
Note: When invoking mypy, a `.mypy_cache` directory is created.