### PR TITLE
Add missing extension to Rust executor

### DIFF
--- a/dmoj/executors/RUST.py
+++ b/dmoj/executors/RUST.py
@@ -66,6 +66,7 @@ fn main() {
 
 
 class Executor(CompiledExecutor):
+    ext = 'rs'
     name = 'RUST'
     command = 'cargo'
     test_program = HELLO_WORLD_PROGRAM


### PR DESCRIPTION
This is in preparation for making extensions mandatory
in all executors.