### PR TITLE
Add mypy types to utils/unicode.py

### DIFF
--- a/dmoj/utils/unicode.py
+++ b/dmoj/utils/unicode.py
@@ -1,18 +1,19 @@
 import codecs
 import sys
+from typing import Optional
 
 
-def utf8bytes(maybe_text):
+def utf8bytes(maybe_text) -> Optional[bytes]:
     if maybe_text is None:
-        return
+        return None
     if isinstance(maybe_text, bytes):
         return maybe_text
     return maybe_text.encode('utf-8')
 
 
-def utf8text(maybe_bytes, errors='strict'):
+def utf8text(maybe_bytes, errors='strict') -> Optional[str]:
     if maybe_bytes is None:
-        return
+        return None
     if isinstance(maybe_bytes, str):
         return maybe_bytes
     return maybe_bytes.decode('utf-8', errors)


### PR DESCRIPTION
mypy considers the original return statements to be
errors since they omit the implicit None.