### PR TITLE
Type command on BaseExecutor as Optional

### DIFF
--- a/dmoj/executors/base_executor.py
+++ b/dmoj/executors/base_executor.py
@@ -21,7 +21,7 @@ version_cache = {}
 
 class BaseExecutor(PlatformExecutorMixin):
     nproc = 0
-    command = None
+    command: Optional[str] = None
     command_paths = []
     runtime_dict = env.runtime
     test_name = 'self_test'


### PR DESCRIPTION
There is an entire class of executors that doesn't
use the command attribute, which is why it's
Optional and not simply str.