### PR TITLE
Limit Clang/++ compile errors; #487

### DIFF
--- a/dmoj/executors/clang_executor.py
+++ b/dmoj/executors/clang_executor.py
@@ -1,8 +1,11 @@
-from .gcc_executor import GCCExecutor
+from .gcc_executor import GCCExecutor, MAX_ERRORS
 
 
 class ClangExecutor(GCCExecutor):
     arch = 'clang_target_arch'
+
+    def get_flags(self):
+        return self.flags + ['-ferror-limit=%d' % MAX_ERRORS]
 
     @classmethod
     def get_version_flags(cls, command):


### PR DESCRIPTION
Closes #487 