### PR TITLE
Add Java 11 executor

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ The DMOJ judge does **not** need a root user to run on Linux machines: it will r
 Supported languages include:
 * C++ 0x/11/14/17 (GCC and Clang)
 * C 99/11
-* Java 7/8/9/10
+* Java 7/8/9/10/11
 * Python 2/3
 * PyPy 2/3
 * Pascal

--- a/dmoj/executors/JAVA11.py
+++ b/dmoj/executors/JAVA11.py
@@ -1,0 +1,35 @@
+from dmoj.executors.java_executor import JavacExecutor
+
+
+class Executor(JavacExecutor):
+    compiler = 'javac11'
+    vm = 'java11'
+    name = 'JAVA11'
+    jvm_regex = r'java-11-|openjdk11'
+
+    test_program = '''\
+import java.io.IOException;
+
+interface IORunnable {
+    public void run() throws IOException;
+}
+
+public class self_test {
+    public static void run(IORunnable target) throws IOException {
+        target.run();
+    }
+
+    public static void main(String[] args) throws IOException {
+        run(() -> {
+            System.out.print("    ".strip());
+
+            var buffer = new byte[4096];
+            int read;
+            while ((read = System.in.read(buffer)) >= 0)
+                System.out.write(buffer, 0, read);
+        });
+    }
+}'''
+
+    def get_compile_args(self):
+        return [self.get_compiler(), '-encoding', 'UTF-8', self._code]


### PR DESCRIPTION
No automated tests for this currently. If we're lucky and `bionic` works, we'll gain Java 9 coverage at most.