### PR TITLE
Revert "Use `Decimal` in floats checker"

### DIFF
--- a/dmoj/tests/test_checker.py
+++ b/dmoj/tests/test_checker.py
@@ -63,9 +63,3 @@ class CheckerTest(unittest.TestCase):
         assert check(b'1 2\n3', b'3\n1 2')
         assert not check(b'1 2\n3', b'3\n2 1')
         assert check(b'1 2\n3', b'3\n2 1', split_on='whitespace')
-
-    def test_floats(self):
-        from dmoj.checkers.floats import check
-
-        assert not check(b'0.' + b'1' * 100, b'0.' + b'1' * 99, high_precision=True, error_mode='absolute')
-        assert check(b'0.' + b'1' * 100, b'0.' + b'1' * 99, error_mode='absolute')


### PR DESCRIPTION
Reverts DMOJ/judge#503.

This is completely broken. The checker will reject anything because `Decimal` constructor does not accept `bytes`. Once that bug is fixed, the inability to control `Decimal`'s precision makes the `assert not check(b'0.' + b'1' * 100, b'0.' + b'1' * 99, high_precision=True, error_mode='absolute')` test case fail, since the numbers do compare equal at default precision.

In other words, the only test case worked by accident.