### PR TITLE
Report rustc version instead of cargo version; fixes #534

### DIFF
--- a/dmoj/executors/RUST.py
+++ b/dmoj/executors/RUST.py
@@ -83,6 +83,10 @@ class Executor(CompiledExecutor):
         with open(self._file('Cargo.lock'), 'wb') as f:
             f.write(CARGO_LOCK)
 
+    @classmethod
+    def get_versionable_commands(cls):
+        return [('rustc', os.path.join(os.path.dirname(cls.command), 'rustc'))]
+
     def get_compile_args(self):
         return [self.get_command(), 'build', '--release']
 

--- a/dmoj/executors/RUST.py
+++ b/dmoj/executors/RUST.py
@@ -85,7 +85,7 @@ class Executor(CompiledExecutor):
 
     @classmethod
     def get_versionable_commands(cls):
-        return [('rustc', os.path.join(os.path.dirname(cls.get_command)_), 'rustc'))]
+        return [('rustc', os.path.join(os.path.dirname(cls.get_command()), 'rustc'))]
 
     def get_compile_args(self):
         return [self.get_command(), 'build', '--release']

--- a/dmoj/executors/RUST.py
+++ b/dmoj/executors/RUST.py
@@ -85,7 +85,7 @@ class Executor(CompiledExecutor):
 
     @classmethod
     def get_versionable_commands(cls):
-        return [('rustc', os.path.join(os.path.dirname(cls.command), 'rustc'))]
+        return [('rustc', os.path.join(os.path.dirname(cls.get_command)_), 'rustc'))]
 
     def get_compile_args(self):
         return [self.get_command(), 'build', '--release']


### PR DESCRIPTION
This will fail if `cargo` isn't in the same directory as `rustc`. I don't think being robust here is worth it.