### PR TITLE
TUR: give tprologc a fake version

### DIFF
--- a/dmoj/executors/TUR.py
+++ b/dmoj/executors/TUR.py
@@ -25,6 +25,10 @@ put echo
         return None
 
     @classmethod
+    def get_runtime_versions(cls):
+        return ('tprologc', (1, 0, 0)),
+    
+    @classmethod
     def initialize(cls):
         if 'tprolog' not in env['runtime'] or 'tprologc' not in env['runtime'] or 'turing_dir' not in env['runtime']:
             return False

--- a/dmoj/executors/TUR.py
+++ b/dmoj/executors/TUR.py
@@ -27,7 +27,7 @@ put echo
     @classmethod
     def get_runtime_versions(cls):
         return ('tprologc', (1, 0, 0)),
-    
+
     @classmethod
     def initialize(cls):
         if 'tprolog' not in env['runtime'] or 'tprologc' not in env['runtime'] or 'turing_dir' not in env['runtime']:


### PR DESCRIPTION
This is so that site-side it may properly appear in the version matrix.