### PR TITLE
Add Generator Compiler Time Limit

### DIFF
--- a/dmoj/generator.py
+++ b/dmoj/generator.py
@@ -2,6 +2,7 @@ import os
 import traceback
 
 from dmoj.error import InternalError
+from dmoj.judgeenv import env
 
 
 class GeneratorManager:
@@ -38,7 +39,7 @@ class GeneratorManager:
         clazz = clazz.Executor
 
         if issubclass(clazz, CompiledExecutor):
-            compiler_time_limit = compiler_time_limit or clazz.compiler_time_limit
+            compiler_time_limit = compiler_time_limit or env.generator_compiler_time_limit
             clazz = type('Executor', (clazz,), {'compiler_time_limit': compiler_time_limit})
 
         # Optimize the common case.

--- a/dmoj/judgeenv.py
+++ b/dmoj/judgeenv.py
@@ -15,8 +15,8 @@ problem_watches = ()
 env = ConfigNode(defaults={
     'selftest_time_limit': 10,  # 10 seconds
     'selftest_memory_limit': 131072,  # 128mb of RAM
-    'generator_compiler_time_limit': 30, # 30 seconds
-    'generator_time_limit': 30,  # 30 seconds
+    'generator_compiler_time_limit': 30,  # 30 seconds
+    'generator_time_limit': 20,  # 20 seconds
     'generator_memory_limit': 524288,  # 512mb of RAM
     'compiler_time_limit': 10,  # Kill compiler after 10 seconds
     'compiler_size_limit': 131072,  # Maximum allowable compiled file size, 128mb

--- a/dmoj/judgeenv.py
+++ b/dmoj/judgeenv.py
@@ -15,7 +15,8 @@ problem_watches = ()
 env = ConfigNode(defaults={
     'selftest_time_limit': 10,  # 10 seconds
     'selftest_memory_limit': 131072,  # 128mb of RAM
-    'generator_time_limit': 20,  # 20 seconds
+    'generator_compiler_time_limit': 30, # 30 seconds
+    'generator_time_limit': 30,  # 30 seconds
     'generator_memory_limit': 524288,  # 512mb of RAM
     'compiler_time_limit': 10,  # Kill compiler after 10 seconds
     'compiler_size_limit': 131072,  # Maximum allowable compiled file size, 128mb


### PR DESCRIPTION
Sets the default generator compiler time limit to 30s, so testlib compilation won't timeout during compilation of generators.