### PR TITLE
Ensure `all_problems` is always a list

### DIFF
--- a/dmoj/commands/problems.py
+++ b/dmoj/commands/problems.py
@@ -25,7 +25,7 @@ class ListProblemsCommand(Command):
 
         if _args.filter:
             r = re.compile(_args.filter)
-            all_problems = filter(lambda x: r.match(x[0]) is not None, all_problems)
+            all_problems = list(filter(lambda x: r.match(x[0]) is not None, all_problems))
 
         if _args.limit:
             all_problems = all_problems[:_args.limit]


### PR DESCRIPTION
Otherwise trying to filter by name yields the error:
```
Traceback (most recent call last):
  File "/usr/local/bin/dmoj-cli", line 11, in <module>
    load_entry_point('dmoj', 'console_scripts', 'dmoj-cli')()
  File "/code/judge/dmoj/cli.py", line 68, in main
    sys.exit(cli_main())
  File "/code/judge/dmoj/cli.py", line 121, in cli_main
    run_command(shlex.split(command))
  File "/code/judge/dmoj/cli.py", line 101, in run_command
    return cmd.execute(line[1:])
  File "/code/judge/dmoj/commands/problems.py", line 33, in execute
    if len(all_problems):
TypeError: object of type 'filter' has no len()
```