### PR TITLE
executors: remove FIXME about posix_fadvise and posix_fallocate

### DIFF
--- a/dmoj/executors/compiled_executor.py
+++ b/dmoj/executors/compiled_executor.py
@@ -163,7 +163,6 @@ class CompilerIsolateTracer(IsolateTracer):
                     sys_rfork: ALLOW,
                     sys_procctl: ALLOW,
                     sys_cap_rights_limit: ALLOW,
-                    # FIXME: this allows changing any FD that is open, not just RW ones.
                     sys_posix_fadvise: ALLOW,
                     sys_posix_fallocate: ALLOW,
                     sys_setrlimit: ALLOW,


### PR DESCRIPTION
* `posix_fadvise` is only a hint for caching, and does not modify the file.
* `posix_fallocate` fails if the fd is opened without write permission.