### PR TITLE
cptbox: compare projected with real instead of normalized

### DIFF
--- a/dmoj/cptbox/isolate.py
+++ b/dmoj/cptbox/isolate.py
@@ -354,7 +354,7 @@ class IsolateTracer(dict):
         real = os.path.realpath(file)
 
         try:
-            same = normalized == real or os.path.samefile(projected, real)
+            same = projected == real or os.path.samefile(projected, real)
         except OSError:
             raise DeniedSyscall(ACCESS_ENOENT, f'Cannot stat, file: {file}, projected: {projected}, real: {real}')
 
@@ -366,7 +366,7 @@ class IsolateTracer(dict):
         if not fs_jail.check(normalized):
             raise DeniedSyscall(ACCESS_EACCES, f'Denying {file}, normalized to {normalized}')
 
-        if normalized != real:
+        if projected != real:
             proc_dir = f'/proc/{debugger.tid}'
             if real.startswith(proc_dir):
                 real = os.path.join('/proc/self', os.path.relpath(real, proc_dir))


### PR DESCRIPTION
We should compare `projected` with `real` instead of `normalized`. This is because if our file is `/proc/self/maps`, the projected will be `/proc/getpid()/maps`, and the real path is `/proc/getpid()/maps`. We do a useless `os.samefile` call in this case.