### PR TITLE
executors: fix typing on `compiler_fs`

### DIFF
--- a/dmoj/cptbox/compiler_isolate.py
+++ b/dmoj/cptbox/compiler_isolate.py
@@ -1,8 +1,9 @@
 import struct
 import sys
+from typing import List
 
 from dmoj.cptbox._cptbox import AT_FDCWD, Debugger
-from dmoj.cptbox.filesystem_policies import ExactFile, FilesystemPolicy, RecursiveDir
+from dmoj.cptbox.filesystem_policies import ExactFile, FilesystemAccessRule, FilesystemPolicy, RecursiveDir
 from dmoj.cptbox.handlers import ACCESS_EFAULT, ACCESS_EPERM, ALLOW
 from dmoj.cptbox.isolate import DeniedSyscall, FilesystemSyscallKind, IsolateTracer
 from dmoj.cptbox.syscalls import *
@@ -14,7 +15,7 @@ UTIME_OMIT = (1 << 30) - 2
 
 
 class CompilerIsolateTracer(IsolateTracer):
-    def __init__(self, *, tmpdir, read_fs, write_fs):
+    def __init__(self, *, tmpdir: str, read_fs: List[FilesystemAccessRule], write_fs: List[FilesystemAccessRule]):
         read_fs += BASE_FILESYSTEM + [
             RecursiveDir(tmpdir),
             ExactFile('/bin/strip'),

--- a/dmoj/cptbox/isolate.py
+++ b/dmoj/cptbox/isolate.py
@@ -2,7 +2,7 @@ import logging
 import os
 import sys
 from enum import Enum
-from typing import Any, Callable, Mapping, Sequence
+from typing import Any, Callable, List, Mapping, Sequence
 
 from dmoj.cptbox._cptbox import AT_FDCWD, Debugger, bsd_get_proc_cwd, bsd_get_proc_fdno
 from dmoj.cptbox.filesystem_policies import FilesystemAccessRule, FilesystemPolicy
@@ -42,7 +42,7 @@ DirFDGetter = Callable[[Debugger], int]
 
 
 class IsolateTracer(dict):
-    def __init__(self, *, read_fs: Sequence[FilesystemAccessRule], write_fs: Sequence[FilesystemAccessRule]):
+    def __init__(self, *, read_fs: List[FilesystemAccessRule], write_fs: List[FilesystemAccessRule]):
         super().__init__()
         self.read_fs_jail = self._compile_fs_jail(read_fs)
         self.write_fs_jail = self._compile_fs_jail(write_fs)

--- a/dmoj/executors/compiled_executor.py
+++ b/dmoj/executors/compiled_executor.py
@@ -1,7 +1,7 @@
 import hashlib
 import os
 import pty
-from typing import Any, Dict, IO, List, Optional, Sequence, Tuple, Union
+from typing import Any, Dict, IO, List, Optional, Tuple, Union
 
 import pylru
 
@@ -78,9 +78,9 @@ class CompiledExecutor(BaseExecutor, metaclass=_CompiledExecutorMeta):
     _executable: Optional[str] = None
     _code: Optional[str] = None
 
-    compiler_read_fs: Sequence[FilesystemAccessRule] = []
-    compiler_write_fs: Sequence[FilesystemAccessRule] = []
-    compiler_syscalls: Sequence[Union[str, Tuple[str, Any]]] = []
+    compiler_read_fs: List[FilesystemAccessRule] = []
+    compiler_write_fs: List[FilesystemAccessRule] = []
+    compiler_syscalls: List[Union[str, Tuple[str, Any]]] = []
 
     # List of directories required by the compiler to be present, typically for writing to
     compiler_required_dirs: List[str] = []


### PR DESCRIPTION
We rely on the `fs` being a list in order to add it to other lists, so we should type it accordingly. MyPy complains about typing in some executors unless they are explicitly typed, see https://mypy.readthedocs.io/en/stable/common_issues.html#variance.