### PR TITLE
executors: increase compiler TL for Pascal

### DIFF
--- a/dmoj/executors/PAS.py
+++ b/dmoj/executors/PAS.py
@@ -8,6 +8,7 @@ class Executor(CompiledExecutor):
     compiler_read_fs = [
         ExactFile('/etc/fpc.cfg'),
     ]
+    compiler_time_limit = 20
     test_program = """\
 var line : string;
 begin


### PR DESCRIPTION
Pascal has been flaking in CI recently, and has a rather long compile time. Notably, re-running the build often makes it pass CI.