### PR TITLE
judge: let problems specify custom limits for cases

### DIFF
--- a/dmoj/commands/test.py
+++ b/dmoj/commands/test.py
@@ -5,7 +5,7 @@ from typing import Any, Dict, Iterable
 from dmoj.commands.base_command import Command
 from dmoj.error import InvalidCommandException
 from dmoj.judgeenv import get_problem_root, get_supported_problems
-from dmoj.problem import ProblemConfig, ProblemDataManager
+from dmoj.problem import ProblemDataManager
 from dmoj.testsuite import Tester
 from dmoj.utils.ansi import ansi_style, print_ansi
 
@@ -14,7 +14,7 @@ class ProblemTester(Tester):
     def run_problem_tests(self, problem_id: str) -> int:
         self.output(ansi_style(f'Testing problem #ansi[{problem_id}](cyan|bold)...'))
 
-        config = ProblemConfig(ProblemDataManager(get_problem_root(problem_id)))
+        config = ProblemDataManager(get_problem_root(problem_id))
 
         if not config or 'tests' not in config or not config['tests']:
             self.output(ansi_style('\t#ansi[Skipped](magenta|bold) - No tests found'))

--- a/dmoj/graders/bridged.py
+++ b/dmoj/graders/bridged.py
@@ -42,8 +42,8 @@ class BridgedInteractiveGrader(StandardGrader):
         self._interactor_stdin_pipe, submission_stdout_pipe = os.pipe()
         submission_stdin_pipe, self._interactor_stdout_pipe = os.pipe()
         self._current_proc = self.binary.launch(
-            time=self.problem.time_limit,
-            memory=self.problem.memory_limit,
+            time=case.time_limit,
+            memory=case.memory_limit,
             symlinks=case.config.symlinks,
             stdin=submission_stdin_pipe,
             stdout=submission_stdout_pipe,

--- a/dmoj/graders/standard.py
+++ b/dmoj/graders/standard.py
@@ -76,8 +76,8 @@ class StandardGrader(BaseGrader):
 
     def _launch_process(self, case):
         self._current_proc = self.binary.launch(
-            time=self.problem.time_limit,
-            memory=self.problem.memory_limit,
+            time=case.time_limit,
+            memory=case.memory_limit,
             symlinks=case.config.symlinks,
             stdin=subprocess.PIPE,
             stdout=subprocess.PIPE,

--- a/dmoj/problem.py
+++ b/dmoj/problem.py
@@ -35,7 +35,7 @@ class Problem:
         # lest globals be deleted with the module.
         self._checkers = {}
 
-        self.config = ProblemConfig(self.problem_data, meta)
+        self.config = ProblemConfig(self.problem_data, time_limit, memory_limit, meta)
 
         self.problem_data.archive = self._resolve_archive_files()
 
@@ -194,7 +194,7 @@ class ProblemDataManager(dict):
 
 
 class ProblemConfig(ConfigNode):
-    def __init__(self, problem_data, meta={}):
+    def __init__(self, problem_data, time_limit, memory_limit, meta={}):
         try:
             doc = yaml.safe_load(problem_data['init.yml'])
         except (IOError, KeyError, ParserError, ScannerError) as e:
@@ -206,6 +206,8 @@ class ProblemConfig(ConfigNode):
                 doc,
                 defaults={
                     'wall_time_factor': 3,
+                    'time_limit': time_limit,
+                    'memory_limit': memory_limit,
                     'output_prefix_length': 0 if 'signature_grader' in doc else 64,
                     'output_limit_length': 25165824,
                     'binary_data': False,
@@ -244,6 +246,8 @@ class TestCase:
         self.config = config
         self.problem = problem
         self.points = config.points
+        self.time_limit = config.time_limit
+        self.memory_limit = config.memory_limit
         self.output_prefix_length = config.output_prefix_length
         self.has_binary_data = config.binary_data
         self._generated = None

--- a/testsuite/case_limits/init.yml
+++ b/testsuite/case_limits/init.yml
@@ -1,0 +1,7 @@
+points: 1
+test_cases:
+  - batched:
+    - {time_limit: 1}
+    memory_limit: 1
+  - {time_limit: 0.0001}
+  - {}

--- a/testsuite/case_limits/tests/custom_limits/test.yml
+++ b/testsuite/case_limits/tests/custom_limits/test.yml
@@ -1,0 +1,5 @@
+language: PY3
+time: 2
+memory: 65536
+source: empty.py
+cases: [MLE, TLE, AC]


### PR DESCRIPTION
Some notes on some potentially weird changes. Leaving a time limit of zero implies no time limit, and similarly with a memory limit of zero. In `test.py`, it's strange to fetch a ProblemConfig, since we never need the functionality that provides.