### PR TITLE
judgeenv: properly specify a default in docker

### DIFF
--- a/dmoj/judgeenv.py
+++ b/dmoj/judgeenv.py
@@ -171,7 +171,7 @@ def load_env(cli=False, testsuite=False):  # pragma: no cover
         with open('/judge-runtime-paths.yml', 'rb') as runtimes_file:
             env.update(yaml.safe_load(runtimes_file))
 
-        problem_dirs = ['/problems']
+        env.problem_storage_root = ['/problems']
 
     model_file = os.path.expanduser(args.config)
     try:


### PR DESCRIPTION
What we probably want to do here is have a default when we are in docker. Right now, if the model_file exists, the default is completely ignored.