### PR TITLE
Type `setproctitle`

### DIFF
--- a/dmoj/judge.py
+++ b/dmoj/judge.py
@@ -27,7 +27,7 @@ try:
     from setproctitle import setproctitle
 except ImportError:
 
-    def setproctitle(title):
+    def setproctitle(title: str) -> None:
         pass
 
 


### PR DESCRIPTION
Fix `All conditional function variants must have identical signatures`, see https://github.com/python/mypy/issues/10575.