### PR TITLE
executors: fix executor setup

### DIFF
--- a/.docker.test.py
+++ b/.docker.test.py
@@ -6,7 +6,7 @@ from dmoj.citest import ci_test
 from dmoj.executors import get_available
 
 arch = platform.machine()
-ALLOW_FAIL = {'GASARM', 'SWIFT'}
+ALLOW_FAIL = {'GASARM', 'ICK', 'SCALA', 'SWIFT'}
 EXECUTORS = get_available()
 
 if arch == 'aarch64':

--- a/dmoj/cptbox/isolate.py
+++ b/dmoj/cptbox/isolate.py
@@ -441,7 +441,7 @@ def wrap_access_check(syscall: int, check: AccessChecker) -> HandlerCallback:
     return inner
 
 
-def protection_fault(self, debugger: Debugger) -> bool:
+def protection_fault(debugger: Debugger) -> bool:
     return False
 
 

--- a/dmoj/executors/DART.py
+++ b/dmoj/executors/DART.py
@@ -1,6 +1,7 @@
 from typing import List
 
 from dmoj.cptbox.filesystem_policies import ExactFile, RecursiveDir
+from dmoj.cptbox.isolate import DeniedSyscall, protection_fault
 from dmoj.executors.compiled_executor import CompiledExecutor
 
 
@@ -28,6 +29,19 @@ void main() {
         'msync',
         'ftruncate',
     ]
+
+    def get_security(self, launch_kwargs=None, extra_fs=None):
+        from dmoj.cptbox.syscalls import sys_execve
+
+        sec = super().get_security(launch_kwargs=launch_kwargs, extra_fs=extra_fs)
+
+        def handle_execve(debugger) -> None:
+            path = debugger.readstr(debugger.uarg0)
+            if path != f'{self.get_command()}vm':
+                raise DeniedSyscall(protection_fault, f'Not allowed to execve: {path}')
+
+        sec[sys_execve] = handle_execve
+        return sec
 
     def get_compile_args(self) -> List[str]:
         command = self.get_command()

--- a/dmoj/executors/HASK.py
+++ b/dmoj/executors/HASK.py
@@ -13,6 +13,7 @@ class Executor(NullStdoutMixin, CompiledExecutor):
         RecursiveDir('/var/lib/ghc'),
     ]
     syscalls = ['pselect6', 'timerfd_settime']
+    compiler_syscalls = ['getresuid', 'getresgid']
     nproc = -1
 
     test_program = """\

--- a/dmoj/executors/java_executor.py
+++ b/dmoj/executors/java_executor.py
@@ -69,6 +69,10 @@ class JavaExecutor(SingleDigitVersionMixin, CompiledExecutor):
         'thr_set_name',
         'getcpu',
     ]
+    compiler_syscalls = [
+        'getresuid',
+        'getresgid',
+    ]
 
     jvm_regex: Optional[str] = None
     _class_name: Optional[str]


### PR DESCRIPTION
* end support for `ICK`
* temporarily end support for `SCALA` (we can re-enable scala after upgrading from 2.11.12 (nov 2017))
* allow `DART` to call `execve` on `/opt/dart-sdk/bin/dartvm`
* allow `HASK` and `KOTLIN` to use `getresuid` and `getresgid`