### PR TITLE
executors/ZIG: update to support 0.15.2

### DIFF
--- a/dmoj/executors/ZIG.py
+++ b/dmoj/executors/ZIG.py
@@ -17,26 +17,25 @@ class Executor(StripCarriageReturnsMixin, CompiledExecutor):
     ]
     compiler_write_fs = compiler_read_fs
     compiler_required_dirs = ['~/.cache']
+    compiler_syscalls = [
+        'preadv',
+        'pwritev',
+        'copy_file_range',
+    ]
     test_program = """
 const std = @import("std");
 
 pub fn main() !void {
-    const io = std.io;
-    const stdin = std.io.getStdIn().inStream();
-    const stdout = std.io.getStdOut().outStream();
-
-    var line_buf: [50]u8 = undefined;
-    while (try stdin.readUntilDelimiterOrEof(&line_buf, '\n')) |line| {
-        if (line.len == 0) break;
-        try stdout.print("{}", .{line});
-    }
+    var buf: [50]u8 = undefined;
+    const n = try std.fs.File.stdin().readAll(&buf);
+    _ = try std.fs.File.stdout().writeAll(buf[0..n-1]);
 }"""
 
     def get_compile_args(self) -> List[str]:
         command = self.get_command()
         assert command is not None
         assert self._code is not None
-        return [command, 'build-exe', self._code, '--release-safe', '--name', self.problem]
+        return [command, 'build-exe', self._code, '-fsingle-threaded', '-O', 'ReleaseSafe', '--name', self.problem]
 
     @classmethod
     def get_version_flags(cls, command: str) -> List[VersionFlags]:


### PR DESCRIPTION
newer version of https://github.com/DMOJ/judge-server/pull/920

make sure to merge this pr, then merge https://github.com/DMOJ/runtimes-docker/pull/93

```
0.555 Testing executors...
0.564 Testing ZIG:    Using /opt/zig/zig
18.42   zig: 0.15.2
18.42 
18.42 Configuration result:
18.42 runtime:
18.42   zig: /opt/zig/zig
18.42 
18.42 Executor configuration succeeded.
```