### PR TITLE
executors: change terminal width to 80

### DIFF
--- a/dmoj/executors/compiled_executor.py
+++ b/dmoj/executors/compiled_executor.py
@@ -139,8 +139,8 @@ class CompiledExecutor(BaseExecutor, metaclass=_CompiledExecutorMeta):
         _master, _slave = pty.openpty()
 
         # Some runtimes helpfully try to word-wrap error messages by determining the width of the screen. Lie and say
-        # we're a 1024x1024 terminal, so they don't try wrapping to 1-column width.
-        fcntl.ioctl(_slave, termios.TIOCSWINSZ, struct.pack('HHHH', 1024, 1024, 0, 0))
+        # we're a 80x1024 terminal, so they don't try wrapping to 1-column width.
+        fcntl.ioctl(_slave, termios.TIOCSWINSZ, struct.pack('HHHH', 1024, 80, 0, 0))
 
         # Some runtimes *cough cough* Swift *cough cough* actually check the environment variables too.
         env = self.get_compile_env() or os.environ.copy()


### PR DESCRIPTION
Scala uses the terminal width to decide how long to make the lines it uses in its error messages.
Currently, the terminal is set to a width of 1024, leading to silly behaviour like this:
<img width="900" height="117" alt="image" src="https://github.com/user-attachments/assets/56ffb7ff-b2ca-4c9c-b5e3-af780642a692" />

By changing the terminal width to 80, we get much more reasonable behaviour
```scala
-- [E053] Type Error: /tmp/tmpas35nd3u/helloworld.scala:3:19 -------------------
3 |    def main(args: String[Array]) = {
  |                   ^^^^^^^^^^^^^
  |                   String does not take type parameters
  |
  | longer explanation available when compiling with `-explain`
1 error found
```
