### PR TITLE
fix: Update compiler OLE message

### DIFF
--- a/dmoj/executors/compiled_executor.py
+++ b/dmoj/executors/compiled_executor.py
@@ -200,7 +200,7 @@ class CompiledExecutor(BaseExecutor, metaclass=_CompiledExecutorMeta):
         try:
             output = safe_communicate(process, None, outlimit=limit, errlimit=limit)[self.compile_output_index]
         except OutputLimitExceeded:
-            output = b'compiler output too long (> 64kb)'
+            output = b'compiler output too long (> %d kb)' % (limit // 1024)
 
         if self.is_failed_compile(process):
             if process.is_tle:


### PR DESCRIPTION
fixes #1200 

Description : 
This PR updates the Output Limit Exceeded (OLE) error message in compiled_executor.py to display the actual configured limit rather than a hardcoded "64kb" value.

Previously, if a server administrator modified env.compiler_output_character_limit, the error message returned to users upon exceeding the limit would still incorrectly report > 64kb.

Changes Made : 
Replaced the hardcoded byte string b'compiler output too long (> 64kb)'.

Implemented dynamic byte-string interpolation using the existing limit variable (b'compiler output too long (> %d bytes)' % limit // 1024).

Testing Instructions : 
Set a custom compiler_output_character_limit in the environment configuration (e.g., 1024 kb).
Submit a solution designed to output excessive compilation warnings/errors.
Verify that the code is working as expected and removes the hardcodedness of >64kb.