### PR TITLE
Fix `feedback` flag

### DIFF
--- a/dmoj/checkers/bridged.py
+++ b/dmoj/checkers/bridged.py
@@ -43,7 +43,7 @@ def check(
     executor = get_executor(problem_id, files, flags, lang, compiler_time_limit)
 
     if type not in contrib_modules:
-        raise InternalError('%s is not a valid contrib module' % type)
+        raise InternalError(f'{type} is not a valid contrib module')
 
     args_format_string = args_format_string or contrib_modules[type].ContribModule.get_checker_args_format_string()
 
@@ -75,7 +75,8 @@ def check(
             point_value,
             time_limit,
             memory_limit,
-            feedback=utf8text(proc_output) if feedback else '',
+            feedback=utf8text(proc_output),
             name='checker',
             stderr=error,
+            show_feedback=feedback,
         )

--- a/dmoj/contrib/base.py
+++ b/dmoj/contrib/base.py
@@ -1,9 +1,10 @@
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, Union
 
 from dmoj.executors.base_executor import BaseExecutor
 
 if TYPE_CHECKING:
     from dmoj.cptbox import TracedPopen
+    from dmoj.result import CheckerResult, Result
 
 
 class BaseContribModule:
@@ -34,5 +35,6 @@ class BaseContribModule:
         feedback: str,
         name: str,
         stderr: bytes,
-    ):
+        show_feedback: bool = True,
+    ) -> Union['CheckerResult', 'Result', bool, None]:
         raise NotImplementedError

--- a/dmoj/contrib/coci.py
+++ b/dmoj/contrib/coci.py
@@ -1,5 +1,5 @@
 import re
-from typing import TYPE_CHECKING
+from typing import Optional, TYPE_CHECKING
 
 from dmoj.contrib.testlib import ContribModule as TestlibContribModule
 from dmoj.error import InternalError
@@ -34,7 +34,8 @@ class ContribModule(TestlibContribModule):
         feedback: str,
         name: str,
         stderr: bytes,
-    ):
+        show_feedback: bool = True,
+    ) -> Optional[CheckerResult]:
         if proc.returncode == cls.PARTIAL:
             match = cls.repartial.search(stderr)
             if not match:
@@ -46,5 +47,5 @@ class ContribModule(TestlibContribModule):
             return CheckerResult(True, points, feedback=feedback)
         else:
             return super().parse_return_code(
-                proc, executor, point_value, time_limit, memory_limit, feedback, name, stderr
+                proc, executor, point_value, time_limit, memory_limit, feedback, name, stderr, show_feedback
             )

--- a/dmoj/contrib/default.py
+++ b/dmoj/contrib/default.py
@@ -1,4 +1,4 @@
-from typing import TYPE_CHECKING
+from typing import Optional, TYPE_CHECKING
 
 from dmoj.contrib.base import BaseContribModule
 from dmoj.executors.base_executor import BaseExecutor
@@ -35,10 +35,15 @@ class ContribModule(BaseContribModule):
         feedback: str,
         name: str,
         stderr: bytes,
-    ):
+        show_feedback: bool = True,
+    ) -> Optional[CheckerResult]:
+        if not show_feedback:
+            feedback = ''
+
         if proc.returncode == cls.AC:
             return CheckerResult(True, point_value, feedback=feedback)
         elif proc.returncode == cls.WA:
             return CheckerResult(False, 0, feedback=feedback)
         else:
             parse_helper_file_error(proc, executor, name, stderr, time_limit, memory_limit)
+            return None

--- a/dmoj/contrib/peg.py
+++ b/dmoj/contrib/peg.py
@@ -1,4 +1,4 @@
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, Union
 
 from dmoj.contrib.base import BaseContribModule
 from dmoj.executors.base_executor import BaseExecutor
@@ -27,7 +27,11 @@ class ContribModule(BaseContribModule):
         feedback: str,
         name: str,
         stderr: bytes,
-    ):
+        show_feedback: bool = True,
+    ) -> Union[CheckerResult, bool, None]:
+        if not show_feedback:
+            feedback = ''
+
         if proc.returncode in (cls.AC, cls.WA):
             # PEG allows for a ratio of floating points, and can give partials for AC or WA
             # Scanning for floating points with a regex is impractical, so we loop all lines
@@ -44,3 +48,4 @@ class ContribModule(BaseContribModule):
             return proc.returncode == cls.AC
         else:
             parse_helper_file_error(proc, executor, name, stderr, time_limit, memory_limit)
+            return None

--- a/dmoj/contrib/testlib.py
+++ b/dmoj/contrib/testlib.py
@@ -1,5 +1,5 @@
 import re
-from typing import TYPE_CHECKING
+from typing import Optional, TYPE_CHECKING
 
 from dmoj.contrib.default import ContribModule as DefaultContribModule
 from dmoj.error import InternalError
@@ -40,22 +40,28 @@ class ContribModule(DefaultContribModule):
         feedback: str,
         name: str,
         stderr: bytes,
-    ):
+        show_feedback: bool = True,
+    ) -> Optional[CheckerResult]:
+        if proc.returncode == cls.IE:  # we handle IE first because it should always return with feedback
+            raise InternalError(f'{name} failed assertion with message {feedback}')
+
+        if not show_feedback:
+            feedback = ''
+
         if proc.returncode == cls.AC:
             return CheckerResult(True, point_value, feedback=feedback)
         elif proc.returncode == cls.PARTIAL:
             match = cls.repartial.search(stderr)
             if not match:
-                raise InternalError('Invalid stderr for partial points: %r' % stderr)
+                raise InternalError(f'Invalid stderr for partial points: {stderr!r}')
             points = int(match.group(1))
             if not 0 <= points <= point_value:
-                raise InternalError('Invalid partial points: %d' % points)
+                raise InternalError(f'Invalid partial points: {points:d}')
             return CheckerResult(True, points, feedback=feedback)
         elif proc.returncode == cls.WA:
             return CheckerResult(False, 0, feedback=feedback)
         elif proc.returncode == cls.PE:
             return CheckerResult(False, 0, feedback=feedback or 'Presentation Error')
-        elif proc.returncode == cls.IE:
-            raise InternalError('%s failed assertion with message %s' % (name, feedback))
         else:
             parse_helper_file_error(proc, executor, name, stderr, time_limit, memory_limit)
+            return None

--- a/dmoj/graders/bridged.py
+++ b/dmoj/graders/bridged.py
@@ -51,9 +51,10 @@ class BridgedInteractiveGrader(StandardGrader):
             case.points,
             self._interactor_time_limit,
             self._interactor_memory_limit,
-            feedback=utf8text(stderr) if self.handler_data.feedback else '',
+            feedback=utf8text(stderr),
             name='interactor',
             stderr=stderr,
+            show_feedback=self.handler_data.feedback,
         )
 
         return (not result.result_flag) and parsed_result


### PR DESCRIPTION
This PR separates `feedback` into an actual `feedback` parameter and a `show_feedback` boolean.
This way we always have `feedback` available for parsing when raising an internal error, but can also choose not to show it to the contestant.

Fixes #1165