### PR TITLE
judge: fix Python 3.14 compatibility with workers

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -61,7 +61,7 @@ jobs:
     runs-on: ubuntu-24.04
     strategy:
       matrix:
-        python-version: ['3.10', '3.11', '3.12', '3.13']
+        python-version: ['3.10', '3.11', '3.12', '3.13', '3.14']
     steps:
       - uses: actions/checkout@v6
       - name: Download docker image
@@ -124,7 +124,7 @@ jobs:
     runs-on: ubuntu-24.04-arm
     strategy:
       matrix:
-        python-version: ['3.10', '3.11', '3.12', '3.13']
+        python-version: ['3.10', '3.11', '3.12', '3.13', '3.14']
     steps:
       - uses: actions/checkout@v6
       - name: Download docker image

--- a/dmoj/judge.py
+++ b/dmoj/judge.py
@@ -321,8 +321,9 @@ class JudgeWorker:
         # FIXME(tbrindus): marked Any pending grader cleanups.
         self.grader: Any = None
 
-        self.worker_process_conn, child_conn = multiprocessing.Pipe()
-        self.worker_process = multiprocessing.Process(
+        self.mp_contex = multiprocessing.get_context('fork')
+        self.worker_process_conn, child_conn = self.mp_contex.Pipe()
+        self.worker_process = self.mp_contex.Process(
             name='DMOJ Judge Handler for %s/%d' % (self.submission.problem_id, self.submission.id),
             target=self._worker_process_main,
             args=(child_conn, self.worker_process_conn),


### PR DESCRIPTION
We are using `multiprocessing` as a funny `fork`, so we are forcing it to do `fork`.

Closes #1243