### PR TITLE
executors/ZIG: update to support 0.16.0

### DIFF
--- a/dmoj/executors/ZIG.py
+++ b/dmoj/executors/ZIG.py
@@ -22,13 +22,14 @@ class Executor(StripCarriageReturnsMixin, CompiledExecutor):
         'pwritev',
         'copy_file_range',
     ]
+    syscalls = ['readv']
     test_program = """
 const std = @import("std");
 
-pub fn main() !void {
+pub fn main(init: std.process.Init) !void {
     var buf: [50]u8 = undefined;
-    const n = try std.fs.File.stdin().readAll(&buf);
-    _ = try std.fs.File.stdout().writeAll(buf[0..n-1]);
+    const n = try std.Io.File.stdin().readStreaming(init.io, &.{&buf});
+    _ = try std.Io.File.stdout().writeStreamingAll(init.io, buf[0..n-1]);
 }"""
 
     def get_compile_args(self) -> List[str]:


### PR DESCRIPTION
newer version of #1221 because zig refactored its library again

i have no idea what `&.{&buf}` means

```
0.527 Testing executors...
0.562 Testing ZIG:    Using /opt/zig/zig
20.89   zig: 0.16.0
20.89
```