### PR TITLE
executors/MONO*: fix compile error involving TERM

### DIFF
--- a/dmoj/executors/compiled_executor.py
+++ b/dmoj/executors/compiled_executor.py
@@ -144,7 +144,7 @@ class CompiledExecutor(BaseExecutor, metaclass=_CompiledExecutorMeta):
 
         # Some runtimes *cough cough* Swift *cough cough* actually check the environment variables too.
         env = self.get_compile_env() or os.environ.copy()
-        env['TERM'] = 'xterm'
+        env.setdefault('TERM', 'xterm')
         # Instruct compilers to put their temporary files into the submission directory,
         # so that we can allow it as writeable, rather than of all of /tmp.
         assert self._dir is not None

--- a/dmoj/executors/mono_executor.py
+++ b/dmoj/executors/mono_executor.py
@@ -45,6 +45,11 @@ class MonoExecutor(CompiledExecutor):
         ('fork', ACCESS_EAGAIN),
     ]
 
+    def get_compile_env(self) -> Dict[str, str]:
+        env = super().get_compile_env() or os.environ.copy()
+        env['TERM'] = 'dumb'
+        return env
+
     def get_env(self) -> Dict[str, str]:
         env = super().get_env()
         # Disable Mono's usage of /dev/shm, so we don't have to deal with


### PR DESCRIPTION
apparently, `env['TERM'] = 'xterm'` causes MONOCS/MONOFS to compile error

the cause is probably `xterm` getting too bloated recently

before:
```
0.536 Testing MONOCS: Failed self-test
0.632   Attempted:
0.632     mono: /usr/bin/mono
0.633     mono-csc: /usr/bin/mono-csc
0.633   Errors:
0.633     Traceback (most recent call last):
...
0.633     dmoj.error.CompileError:
0.633     Unhandled Exception:
0.633     System.TypeInitializationException: The type initializer for 'System.Console' threw an exception. ---> System.TypeInitializationException: The type initializer for 'System.ConsoleDriver' threw an exception. ---> System.Exception: File must be smaller than 4K
```

after:
```
0.672 Testing MONOCS: Success
1.525   csc: 6.12.0.200
1.536   mono: 6.12.0.200
```