### PR TITLE
executors/NODEJS: add data grace

### DIFF
--- a/dmoj/executors/NODEJS.py
+++ b/dmoj/executors/NODEJS.py
@@ -10,6 +10,7 @@ class Executor(ScriptExecutor):
     command_paths = ['node', 'nodejs']
     syscalls = ['capget', 'eventfd2', 'shutdown', 'pkey_alloc', 'pkey_free', ('io_uring_setup', ACCESS_ENOSYS)]
     address_grace = 1048576
+    data_grace = 524288
     test_program = """
 process.stdin.on('readable', () => {
     const chunk = process.stdin.read();


### PR DESCRIPTION
before:
```
0.607 Testing NODEJS: terminate called after throwing an instance of 'std::bad_alloc'
0.660   what():  std::bad_alloc
0.663 Failed self-test
0.664   Attempted:
0.665     node: /usr/bin/node
0.665   Errors:
0.665     Got unexpected stdout output:
```

after:
```
0.504 Testing NODEJS: Using /usr/bin/node
0.743   node: 24.18.0
```