### PR TITLE
executors/LEAN4: reduce memory use and increase grace

### DIFF
--- a/dmoj/cptbox/isolate.py
+++ b/dmoj/cptbox/isolate.py
@@ -357,9 +357,12 @@ class IsolateTracer(dict):
             file = os.path.join(f'/proc/{debugger.tid}', os.path.relpath(file, '/proc/self'))
             projected = '/' + os.path.normpath(file).lstrip('/')
         elif normalized.startswith(f'/proc/{debugger.tid}/'):
-            # If the child process uses /proc/getpid()/foo, set the normalized path to be /proc/self/foo.
+            # If the child process uses /proc/[tid]/foo, set the normalized path to be /proc/self/foo.
             # Access rules can more easily check /proc/self.
             normalized = os.path.join('/proc/self', os.path.relpath(file, f'/proc/{debugger.tid}'))
+        elif normalized.startswith(f'/proc/{debugger.pid}/'):
+            # Normalize /proc/[pid]/foo to /proc/self/foo. LEAN4 uses this.
+            normalized = os.path.join('/proc/self', os.path.relpath(file, f'/proc/{debugger.pid}'))
         real = os.path.realpath(file)
 
         try:

--- a/dmoj/executors/LEAN4.py
+++ b/dmoj/executors/LEAN4.py
@@ -1,3 +1,5 @@
+from typing import Dict
+
 from dmoj.executors.compiled_executor import CompiledExecutor
 
 
@@ -12,6 +14,8 @@ def main : IO Unit := do
 """
     nproc = -1
     syscalls = ['eventfd2']
+    address_grace = 1088 * 1024
+    data_grace = 1088 * 1024
 
     def compile(self) -> str:
         command = self.get_command()
@@ -28,3 +32,11 @@ def main : IO Unit := do
         self.warning = b'\n'.join(filter(None, [out1, out2]))
         self._executable = self.get_compiled_file()
         return self._executable
+
+    def get_env(self) -> Dict[str, str]:
+        env = super().get_env()
+        env['LEAN_MAIN_USE_THREAD'] = '0'
+        env['LEAN_NUM_THREADS'] = '0'
+        # Don't change LEAN_STACK_SIZE_KB.
+        env['MIMALLOC_ARENA_RESERVE'] = '65536'  # KiB
+        return env


### PR DESCRIPTION
before:
```
0.521 Testing LEAN4:  Failed self-test
1.111   Attempted:
1.111     lean: /opt/lean/bin/lean
1.112   Errors:
1.112     Traceback (most recent call last):
...
1.112     dmoj.error.CompileError: uncaught exception: failed to locate application
```

after the `isolate.py` fix:
```
0.507 Testing LEAN4:  libc++abi: terminating due to uncaught exception of type lean::exception: failed to create thread                                 
1.414 Failed self-test
1.414   Attempted:
1.414     lean: /opt/lean/bin/lean
1.415   Errors:
1.415     Got unexpected stdout output:
```

after the `LEAN4.py` fix:
```
0.518 Testing LEAN4:  Using /opt/lean/bin/lean
1.563   lean: 4.32.2
```

`LEAN_MAIN_USE_THREAD` and `MIMALLOC_ARENA_RESERVE` reduce the grace needed. `LEAN_NUM_THREADS` reduces the grace for programs that spawn threads (maybe?) (i can't imagine users using multithreading).

the grace is 1gb for the main thread, plus 64mb for mimalloc.