### PR TITLE
cptbox: allow `sys_clock_nanosleep` for `NODEJS`

### DIFF
--- a/dmoj/cptbox/isolate.py
+++ b/dmoj/cptbox/isolate.py
@@ -147,6 +147,7 @@ class IsolateTracer(dict):
                 sys_clock_gettime: ALLOW,
                 sys_clock_gettime64: ALLOW,
                 sys_clock_getres: ALLOW,
+                sys_clock_nanosleep: ALLOW,
                 sys_gettimeofday: ALLOW,
                 sys_getpid: ALLOW,
                 sys_getppid: ALLOW,


### PR DESCRIPTION
`NODEJS` fails due to `sys_clock_nanosleep` being denied, but we already allow `sys_nanosleep`, `sys_clock_getres`, and `sys_block_gettime` so there's no reason to deny it.